### PR TITLE
Add functionality from tf_slim to replace tf.contrib functionality

### DIFF
--- a/astronet/astro_fc_model/astro_fc_model.py
+++ b/astronet/astro_fc_model/astro_fc_model.py
@@ -53,108 +53,112 @@ from __future__ import print_function
 import tensorflow as tf
 
 from astronet.astro_model import astro_model
+import astronet.astro_fc_model.layers as layers
 
 
 class AstroFCModel(astro_model.AstroModel):
-  """A model for classifying light curves using fully connected layers."""
+    """A model for classifying light curves using fully connected layers."""
 
-  def __init__(self, features, labels, hparams, mode):
-    """Basic setup. The actual TensorFlow graph is constructed in build().
+    def __init__(self, features, labels, hparams, mode):
+        """Basic setup. The actual TensorFlow graph is constructed in build().
 
-    Args:
-      features: A dictionary containing "time_series_features" and
-          "aux_features", each of which is a dictionary of named input Tensors.
-          All features have dtype float32 and shape [batch_size, length].
-      labels: An int64 Tensor with shape [batch_size]. May be None if mode is
-          tf.estimator.ModeKeys.PREDICT.
-      hparams: A ConfigDict of hyperparameters for building the model.
-      mode: A tf.estimator.ModeKeys to specify whether the graph should be built
-          for training, evaluation or prediction.
+        Args:
+          features: A dictionary containing "time_series_features" and
+              "aux_features", each of which is a dictionary of named input Tensors.
+              All features have dtype float32 and shape [batch_size, length].
+          labels: An int64 Tensor with shape [batch_size]. May be None if mode is
+              tf.estimator.ModeKeys.PREDICT.
+          hparams: A ConfigDict of hyperparameters for building the model.
+          mode: A tf.estimator.ModeKeys to specify whether the graph should be built
+              for training, evaluation or prediction.
 
-    Raises:
-      ValueError: If mode is invalid.
-    """
-    super(AstroFCModel, self).__init__(features, labels, hparams, mode)
+        Raises:
+          ValueError: If mode is invalid.
+        """
+        super(AstroFCModel, self).__init__(features, labels, hparams, mode)
 
-  def _build_local_fc_layers(self, inputs, hparams, scope):
-    """Builds locally fully connected layers.
+    def _build_local_fc_layers(self, inputs, hparams, scope):
+        """Builds locally fully connected layers.
 
-    Note that the first layer of the fully connected stack is optionally
-    implemented as a convolution with a wide kernel followed by pooling. This
-    makes the fully connected stack invariant to small translations of its
-    input.
+        Note that the first layer of the fully connected stack is optionally
+        implemented as a convolution with a wide kernel followed by pooling. This
+        makes the fully connected stack invariant to small translations of its
+        input.
 
-    Args:
-      inputs: A Tensor of shape [batch_size, length].
-      hparams: Object containing hyperparameters.
-      scope: Name of the variable scope.
+        Args:
+          inputs: A Tensor of shape [batch_size, length].
+          hparams: Object containing hyperparameters.
+          scope: Name of the variable scope.
 
-    Returns:
-      A Tensor of shape [batch_size, hparams.local_layer_size].
+        Returns:
+          A Tensor of shape [batch_size, hparams.local_layer_size].
 
-    Raises:
-      ValueError: If hparams.pooling_type is unrecognized.
-    """
-    if hparams.num_local_layers == 0:
-      return inputs
+        Raises:
+          ValueError: If hparams.pooling_type is unrecognized.
+        """
+        if hparams.num_local_layers == 0:
+            return inputs
 
-    net = inputs
-    with tf.compat.v1.variable_scope(scope):
-      # First layer is optionally implemented as a wide convolution for
-      # invariance to small translations.
-      if hparams.translation_delta > 0:
-        kernel_size = inputs.shape.as_list()[1] - 2 * hparams.translation_delta
-        net = tf.expand_dims(net, -1)  # [batch, length, channels=1]
-        net = tf.compat.v1.layers.conv1d(
-            inputs=net,
-            filters=hparams.local_layer_size,
-            kernel_size=kernel_size,
-            padding="valid",
-            activation=tf.nn.relu,
-            name="conv1d")
+        net = inputs
+        with tf.compat.v1.variable_scope(scope):
+            # First layer is optionally implemented as a wide convolution for
+            # invariance to small translations.
+            if hparams.translation_delta > 0:
+                kernel_size = inputs.shape.as_list(
+                )[1] - 2 * hparams.translation_delta
+                net = tf.expand_dims(net, -1)  # [batch, length, channels=1]
+                net = tf.compat.v1.layers.conv1d(
+                    inputs=net,
+                    filters=hparams.local_layer_size,
+                    kernel_size=kernel_size,
+                    padding="valid",
+                    activation=tf.nn.relu,
+                    name="conv1d")
 
-        # net is [batch, length, num_filters], where length = 1 +
-        # 2 * translation_delta. Pool along the length dimension.
-        if hparams.pooling_type == "max":
-          net = tf.reduce_max(input_tensor=net, axis=1, name="max_pool")
-        elif hparams.pooling_type == "avg":
-          net = tf.reduce_mean(input_tensor=net, axis=1, name="avg_pool")
-        else:
-          raise ValueError(
-              "Unrecognized pooling_type: %s" % hparams.pooling_type)
+                # net is [batch, length, num_filters], where length = 1 +
+                # 2 * translation_delta. Pool along the length dimension.
+                if hparams.pooling_type == "max":
+                    net = tf.reduce_max(
+                        input_tensor=net, axis=1, name="max_pool")
+                elif hparams.pooling_type == "avg":
+                    net = tf.reduce_mean(
+                        input_tensor=net, axis=1, name="avg_pool")
+                else:
+                    raise ValueError(
+                        "Unrecognized pooling_type: %s" % hparams.pooling_type)
 
-        remaining_layers = hparams.num_local_layers - 1
-      else:
-        remaining_layers = hparams.num_local_layers
+                remaining_layers = hparams.num_local_layers - 1
+            else:
+                remaining_layers = hparams.num_local_layers
 
-      # Remaining fully connected layers.
-      for i in range(remaining_layers):
-        net = tf.contrib.layers.fully_connected(
-            inputs=net,
-            num_outputs=hparams.local_layer_size,
-            activation_fn=tf.nn.relu,
-            scope="fully_connected_%d" % (i + 1))
+            # Remaining fully connected layers.
+            for i in range(remaining_layers):
+                net = layers.fully_connected(
+                    inputs=net,
+                    num_outputs=hparams.local_layer_size,
+                    activation_fn=tf.nn.relu,
+                    scope="fully_connected_%d" % (i + 1))
 
-        if hparams.dropout_rate > 0:
-          net = tf.compat.v1.layers.dropout(
-              net, hparams.dropout_rate, training=self.is_training)
+                if hparams.dropout_rate > 0:
+                    net = tf.compat.v1.layers.dropout(
+                        net, hparams.dropout_rate, training=self.is_training)
 
-    return net
+        return net
 
-  def build_time_series_hidden_layers(self):
-    """Builds hidden layers for the time series features.
+    def build_time_series_hidden_layers(self):
+        """Builds hidden layers for the time series features.
 
-    Inputs:
-      self.time_series_features
+        Inputs:
+          self.time_series_features
 
-    Outputs:
-      self.time_series_hidden_layers
-    """
-    time_series_hidden_layers = {}
-    for name, time_series in self.time_series_features.items():
-      time_series_hidden_layers[name] = self._build_local_fc_layers(
-          inputs=time_series,
-          hparams=self.hparams.time_series_hidden[name],
-          scope=name + "_hidden")
+        Outputs:
+          self.time_series_hidden_layers
+        """
+        time_series_hidden_layers = {}
+        for name, time_series in self.time_series_features.items():
+            time_series_hidden_layers[name] = self._build_local_fc_layers(
+                inputs=time_series,
+                hparams=self.hparams.time_series_hidden[name],
+                scope=name + "_hidden")
 
-    self.time_series_hidden_layers = time_series_hidden_layers
+        self.time_series_hidden_layers = time_series_hidden_layers

--- a/astronet/astro_fc_model/initializers.py
+++ b/astronet/astro_fc_model/initializers.py
@@ -1,0 +1,154 @@
+# coding=utf-8
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Weight initializers for use with layers."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import math
+# pylint: disable=g-direct-tensorflow-import
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import random_ops
+
+
+__all__ = ['xavier_initializer', 'xavier_initializer_conv2d',
+           'variance_scaling_initializer']
+
+
+def xavier_initializer(uniform=True, seed=None, dtype=dtypes.float32):
+  """Returns an initializer performing "Xavier" initialization for weights.
+
+  This function implements the weight initialization from:
+
+  Xavier Glorot and Yoshua Bengio (2010):
+           [Understanding the difficulty of training deep feedforward neural
+           networks. International conference on artificial intelligence and
+           statistics.](
+           http://www.jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf)
+
+  This initializer is designed to keep the scale of the gradients roughly the
+  same in all layers. In uniform distribution this ends up being the range:
+  `x = sqrt(6. / (in + out)); [-x, x]` and for normal distribution a standard
+  deviation of `sqrt(2. / (in + out))` is used.
+
+  Args:
+    uniform: Whether to use uniform or normal distributed random initialization.
+    seed: A Python integer. Used to create random seeds. See
+          `tf.compat.v1.set_random_seed` for behavior.
+    dtype: The data type. Only floating point types are supported.
+
+  Returns:
+    An initializer for a weight matrix.
+  """
+  return variance_scaling_initializer(factor=1.0, mode='FAN_AVG',
+                                      uniform=uniform, seed=seed, dtype=dtype)
+
+xavier_initializer_conv2d = xavier_initializer
+
+
+def variance_scaling_initializer(factor=2.0, mode='FAN_IN', uniform=False,
+                                 seed=None, dtype=dtypes.float32):
+  """Returns an initializer that generates tensors without scaling variance.
+
+  When initializing a deep network, it is in principle advantageous to keep
+  the scale of the input variance constant, so it does not explode or diminish
+  by reaching the final layer. This initializer use the following formula:
+
+  ```python
+    if mode='FAN_IN': # Count only number of input connections.
+      n = fan_in
+    elif mode='FAN_OUT': # Count only number of output connections.
+      n = fan_out
+    elif mode='FAN_AVG': # Average number of inputs and output connections.
+      n = (fan_in + fan_out)/2.0
+
+      truncated_normal(shape, 0.0, stddev=sqrt(factor / n))
+  ```
+
+  * To get [Delving Deep into Rectifiers](
+     http://arxiv.org/pdf/1502.01852v1.pdf) (also know as the "MSRA
+     initialization"), use (Default):<br/>
+    `factor=2.0 mode='FAN_IN' uniform=False`
+  * To get [Convolutional Architecture for Fast Feature Embedding](
+     http://arxiv.org/abs/1408.5093), use:<br/>
+    `factor=1.0 mode='FAN_IN' uniform=True`
+  * To get [Understanding the difficulty of training deep feedforward neural
+    networks](http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf),
+    use:<br/>
+    `factor=1.0 mode='FAN_AVG' uniform=True.`
+  * To get `xavier_initializer` use either:<br/>
+    `factor=1.0 mode='FAN_AVG' uniform=True`, or<br/>
+    `factor=1.0 mode='FAN_AVG' uniform=False`.
+
+  Args:
+    factor: Float.  A multiplicative factor.
+    mode: String.  'FAN_IN', 'FAN_OUT', 'FAN_AVG'.
+    uniform: Whether to use uniform or normal distributed random initialization.
+    seed: A Python integer. Used to create random seeds. See
+          `tf.compat.v1.set_random_seed` for behavior.
+    dtype: The data type. Only floating point types are supported.
+
+  Returns:
+    An initializer that generates tensors with unit variance.
+
+  Raises:
+    ValueError: if `dtype` is not a floating point type.
+    TypeError: if `mode` is not in ['FAN_IN', 'FAN_OUT', 'FAN_AVG'].
+  """
+  if not dtype.is_floating:
+    raise TypeError('Cannot create initializer for non-floating point type.')
+  if mode not in ['FAN_IN', 'FAN_OUT', 'FAN_AVG']:
+    raise TypeError('Unknown mode %s [FAN_IN, FAN_OUT, FAN_AVG]' % mode)
+
+  # pylint: disable=unused-argument
+  def _initializer(shape, dtype=dtype, partition_info=None):
+    """Initializer function."""
+    if not dtype.is_floating:
+      raise TypeError('Cannot create initializer for non-floating point type.')
+    # Estimating fan_in and fan_out is not possible to do perfectly, but we try.
+    # This is the right thing for matrix multiply and convolutions.
+    if shape:
+      fan_in = float(shape[-2]) if len(shape) > 1 else float(shape[-1])
+      fan_out = float(shape[-1])
+    else:
+      fan_in = 1.0
+      fan_out = 1.0
+    for dim in shape[:-2]:
+      fan_in *= float(dim)
+      fan_out *= float(dim)
+    if mode == 'FAN_IN':
+      # Count only number of input connections.
+      n = fan_in
+    elif mode == 'FAN_OUT':
+      # Count only number of output connections.
+      n = fan_out
+    elif mode == 'FAN_AVG':
+      # Average number of inputs and output connections.
+      n = (fan_in + fan_out) / 2.0
+    if uniform:
+      # To get stddev = math.sqrt(factor / n) need to adjust for uniform.
+      limit = math.sqrt(3.0 * factor / n)
+      return random_ops.random_uniform(shape, -limit, limit,
+                                       dtype, seed=seed)
+    else:
+      # To get stddev = math.sqrt(factor / n) need to adjust for truncated.
+      trunc_stddev = math.sqrt(1.3 * factor / n)
+      return random_ops.truncated_normal(shape, 0.0, trunc_stddev, dtype,
+                                         seed=seed)
+  # pylint: enable=unused-argument
+
+  return _initializer

--- a/astronet/astro_fc_model/layers.py
+++ b/astronet/astro_fc_model/layers.py
@@ -1,0 +1,3392 @@
+# coding=utf-8
+# -*- coding: utf-8 -*-
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# pylint: disable=g-short-docstring-punctuation
+"""Higher level ops for building layers."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+import six
+import tensorflow.compat.v1 as tf
+import astronet.astro_fc_model.initializers as initializers
+import astronet.astro_fc_model.utils as utils
+import astronet.ops.variables as variables
+from astronet.ops.arg_scope import add_arg_scope
+
+# pylint: disable=g-direct-tensorflow-import
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import sparse_tensor
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.keras.engine import input_spec
+from tensorflow.python.layers import base
+from tensorflow.python.layers import convolutional as convolutional_layers
+from tensorflow.python.layers import core as core_layers
+from tensorflow.python.layers import normalization as normalization_layers
+from tensorflow.python.layers import pooling as pooling_layers
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import check_ops
+from tensorflow.python.ops import custom_gradient
+from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import linalg_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn
+from tensorflow.python.ops import sparse_ops
+from tensorflow.python.ops import standard_ops
+from tensorflow.python.ops import variable_scope
+from tensorflow.python.ops import variables as tf_variables
+from tensorflow.python.training import moving_averages
+
+# TODO(b/28426988): Replace legacy_* fns migrated from slim.
+# TODO(b/28426988): Remove legacy_* when all uses have migrated to new API.
+__all__ = [
+    'avg_pool2d', 'avg_pool3d', 'batch_norm', 'bias_add', 'conv1d', 'conv2d',
+    'conv3d', 'conv2d_in_plane', 'conv2d_transpose', 'conv3d_transpose',
+    'convolution', 'convolution1d', 'convolution2d', 'convolution2d_in_plane',
+    'convolution2d_transpose', 'convolution3d', 'convolution3d_transpose',
+    'dense_to_sparse', 'dropout', 'elu', 'flatten', 'fully_connected', 'GDN',
+    'gdn', 'images_to_sequence', 'layer_norm', 'linear', 'pool', 'max_pool2d',
+    'max_pool3d', 'one_hot_encoding', 'relu', 'relu6', 'repeat',
+    'scale_gradient', 'separable_conv2d', 'separable_convolution2d',
+    'sequence_to_images', 'softmax', 'spatial_softmax', 'stack', 'unit_norm',
+    'legacy_fully_connected', 'legacy_linear', 'legacy_relu', 'maxout'
+]
+
+DATA_FORMAT_NCHW = 'NCHW'
+DATA_FORMAT_NHWC = 'NHWC'
+DATA_FORMAT_NCDHW = 'NCDHW'
+DATA_FORMAT_NDHWC = 'NDHWC'
+
+
+@add_arg_scope
+def avg_pool2d(inputs,
+               kernel_size,
+               stride=2,
+               padding='VALID',
+               data_format=DATA_FORMAT_NHWC,
+               outputs_collections=None,
+               scope=None):
+    """Adds a 2D average pooling op.
+
+    It is assumed that the pooling is done per image but not in batch or channels.
+
+    Args:
+      inputs: A 4-D tensor of shape `[batch_size, height, width, channels]` if
+        `data_format` is `NHWC`, and `[batch_size, channels, height, width]` if
+        `data_format` is `NCHW`.
+      kernel_size: A list of length 2: [kernel_height, kernel_width] of the
+        pooling kernel over which the op is computed. Can be an int if both values
+        are the same.
+      stride: A list of length 2: [stride_height, stride_width]. Can be an int if
+        both strides are the same. Note that presently both strides must have the
+        same value.
+      padding: The padding method, either 'VALID' or 'SAME'.
+      data_format: A string. `NHWC` (default) and `NCHW` are supported.
+      outputs_collections: The collections to which the outputs are added.
+      scope: Optional scope for name_scope.
+
+    Returns:
+      A `Tensor` representing the results of the pooling operation.
+
+    Raises:
+      ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+    """
+    if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+        raise ValueError('data_format has to be either NCHW or NHWC.')
+    with ops.name_scope(scope, 'AvgPool2D', [inputs]) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        df = ('channels_first'
+              if data_format and data_format.startswith('NC') else 'channels_last')
+        layer = pooling_layers.AveragePooling2D(
+            pool_size=kernel_size,
+            strides=stride,
+            padding=padding,
+            data_format=df,
+            _scope=sc)
+        outputs = layer.apply(inputs)
+        return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def avg_pool3d(inputs,
+               kernel_size,
+               stride=2,
+               padding='VALID',
+               data_format=DATA_FORMAT_NDHWC,
+               outputs_collections=None,
+               scope=None):
+    """Adds a 3D average pooling op.
+
+    It is assumed that the pooling is done per image but not in batch or channels.
+
+    Args:
+      inputs: A 5-D tensor of shape `[batch_size, depth, height, width, channels]`
+        if `data_format` is `NDHWC`, and `[batch_size, channels, depth, height,
+        width]` if `data_format` is `NCDHW`.
+      kernel_size: A list of length 3: [kernel_depth, kernel_height, kernel_width]
+        of the pooling kernel over which the op is computed. Can be an int if both
+        values are the same.
+      stride: A list of length 3: [stride_depth, stride_height, stride_width]. Can
+        be an int if both strides are the same. Note that presently both strides
+        must have the same value.
+      padding: The padding method, either 'VALID' or 'SAME'.
+      data_format: A string. `NDHWC` (default) and `NCDHW` are supported.
+      outputs_collections: The collections to which the outputs are added.
+      scope: Optional scope for name_scope.
+
+    Returns:
+      A `Tensor` representing the results of the pooling operation.
+
+    Raises:
+      ValueError: If `data_format` is neither `NDHWC` nor `NCDHW`.
+    """
+    if data_format not in (DATA_FORMAT_NCDHW, DATA_FORMAT_NDHWC):
+        raise ValueError('data_format has to be either NCDHW or NDHWC.')
+    with ops.name_scope(scope, 'AvgPool3D', [inputs]) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        df = ('channels_first'
+              if data_format and data_format.startswith('NC') else 'channels_last')
+        layer = pooling_layers.AveragePooling3D(
+            pool_size=kernel_size,
+            strides=stride,
+            padding=padding,
+            data_format=df,
+            _scope=sc)
+        outputs = layer.apply(inputs)
+        return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+def _fused_batch_norm(inputs,
+                      decay=0.999,
+                      center=True,
+                      scale=False,
+                      epsilon=0.001,
+                      activation_fn=None,
+                      param_initializers=None,
+                      param_regularizers=None,
+                      updates_collections=ops.GraphKeys.UPDATE_OPS,
+                      is_training=True,
+                      reuse=None,
+                      variables_collections=None,
+                      outputs_collections=None,
+                      trainable=True,
+                      data_format=DATA_FORMAT_NHWC,
+                      zero_debias_moving_mean=False,
+                      scope=None):
+    """Adds a Batch Normalization layer from http://arxiv.org/abs/1502.03167.
+
+      "Batch Normalization: Accelerating Deep Network Training by Reducing
+      Internal Covariate Shift"
+
+      Sergey Ioffe, Christian Szegedy
+
+    Can be used as a normalizer function for conv2d and fully_connected.
+
+    Note: when training, the moving_mean and moving_variance need to be updated.
+    By default the update ops are placed in `tf.GraphKeys.UPDATE_OPS`, so they
+    need to be added as a dependency to the `train_op`. For example:
+
+    ```python
+      update_ops = tf.compat.v1.get_collection(tf.GraphKeys.UPDATE_OPS)
+      with tf.control_dependencies(update_ops):
+        train_op = optimizer.minimize(loss)
+    ```
+
+    One can set updates_collections=None to force the updates in place, but that
+    can have a speed penalty, especially in distributed settings.
+
+    Args:
+      inputs: A tensor with 2 or more dimensions, where the first dimension has
+        `batch_size`. The normalization is over all but the last dimension if
+        `data_format` is `NHWC` and the second dimension if `data_format` is
+        `NCHW`.
+      decay: Decay for the moving average. Reasonable values for `decay` are close
+        to 1.0, typically in the multiple-nines range: 0.999, 0.99, 0.9, etc.
+          Lower `decay` value (recommend trying `decay`=0.9) if model experiences
+          reasonably good training performance but poor validation and/or test
+          performance.
+      center: If True, add offset of `beta` to normalized tensor.  If False,
+        `beta` is ignored.
+      scale: If True, multiply by `gamma`. If False, `gamma` is not used. When the
+        next layer is linear (also e.g. `nn.relu`), this can be disabled since the
+        scaling can be done by the next layer.
+      epsilon: Small float added to variance to avoid dividing by zero.
+      activation_fn: Activation function, default set to None to skip it and
+        maintain a linear activation.
+      param_initializers: Optional initializers for beta, gamma, moving mean and
+        moving variance.
+      param_regularizers: Optional regularizer for beta and gamma.
+      updates_collections: Collections to collect the update ops for computation.
+        The updates_ops need to be executed with the train_op. If None, a control
+        dependency would be added to make sure the updates are computed in place.
+      is_training: Whether or not the layer is in training mode. In training mode
+        it would accumulate the statistics of the moments into `moving_mean` and
+        `moving_variance` using an exponential moving average with the given
+        `decay`. When it is not in training mode then it would use the values of
+        the `moving_mean` and the `moving_variance`.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional collections for the variables.
+      outputs_collections: Collections to add the outputs.
+      trainable: If `True` also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+      data_format: A string. `NHWC` (default) and `NCHW` are supported.
+      zero_debias_moving_mean: Use zero_debias for moving_mean.
+      scope: Optional scope for `variable_scope`.
+
+    Returns:
+      A `Tensor` representing the output of the operation.
+
+    Raises:
+      ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+      ValueError: If the rank of `inputs` is undefined.
+      ValueError: If the rank of `inputs` is neither 2 or 4.
+      ValueError: If rank or `C` dimension of `inputs` is undefined.
+    """
+    if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+        raise ValueError('data_format has to be either NCHW or NHWC.')
+    with variable_scope.variable_scope(
+            scope, 'BatchNorm', [inputs], reuse=reuse) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        original_shape = inputs.get_shape()
+        original_inputs = inputs
+        original_rank = original_shape.ndims
+        if original_rank is None:
+            raise ValueError('Inputs %s has undefined rank' % inputs.name)
+        elif original_rank not in [2, 4]:
+            raise ValueError('Inputs %s has unsupported rank.'
+                             ' Expected 2 or 4 but got %d' %
+                             (inputs.name, original_rank))
+        if original_rank == 2:
+            channels = inputs.get_shape().dims[-1].value
+            if channels is None:
+                raise ValueError('`C` dimension must be known but is None')
+            new_shape = [-1, 1, 1, channels]
+            if data_format == DATA_FORMAT_NCHW:
+                new_shape = [-1, channels, 1, 1]
+            inputs = array_ops.reshape(inputs, new_shape)
+        inputs_shape = inputs.get_shape()
+        if data_format == DATA_FORMAT_NHWC:
+            params_shape = inputs_shape[-1:]
+        else:
+            params_shape = inputs_shape[1:2]
+        if not params_shape.is_fully_defined():
+            raise ValueError('Inputs %s has undefined `C` dimension %s.' %
+                             (inputs.name, params_shape))
+
+        # Allocate parameters for the beta and gamma of the normalization.
+        beta_collections = utils.get_variable_collections(variables_collections,
+                                                          'beta')
+        # Float32 required to avoid precision-loss when using fp16 input/output
+        variable_dtype = dtypes.float32
+        if not param_initializers:
+            param_initializers = {}
+        if not param_regularizers:
+            param_regularizers = {}
+        beta_regularizer = param_regularizers.get('beta')
+        gamma_regularizer = param_regularizers.get('gamma')
+
+        if center:
+            beta_initializer = param_initializers.get('beta',
+                                                      init_ops.zeros_initializer())
+            beta = variables.model_variable(
+                'beta',
+                shape=params_shape,
+                dtype=variable_dtype,
+                initializer=beta_initializer,
+                regularizer=beta_regularizer,
+                collections=beta_collections,
+                trainable=trainable)
+        else:
+            beta = array_ops.constant(
+                0.0, dtype=variable_dtype, shape=params_shape)
+
+        if scale:
+            gamma_collections = utils.get_variable_collections(
+                variables_collections, 'gamma')
+            gamma_initializer = param_initializers.get('gamma',
+                                                       init_ops.ones_initializer())
+            gamma = variables.model_variable(
+                'gamma',
+                shape=params_shape,
+                dtype=variable_dtype,
+                initializer=gamma_initializer,
+                regularizer=gamma_regularizer,
+                collections=gamma_collections,
+                trainable=trainable)
+        else:
+            gamma = array_ops.constant(
+                1.0, dtype=variable_dtype, shape=params_shape)
+
+        # Create moving_mean and moving_variance variables and add them to the
+        # appropriate collections. We disable variable partitioning while creating
+        # them, because assign_moving_average is not yet supported for partitioned
+        # variables (this needs to be handled carefully, as it may break
+        # the checkpoint backward compatibility).
+        with variable_scope.variable_scope(
+                variable_scope.get_variable_scope()) as local_scope:
+            local_scope.set_partitioner(None)
+            moving_mean_collections = utils.get_variable_collections(
+                variables_collections, 'moving_mean')
+            moving_mean_initializer = param_initializers.get(
+                'moving_mean', init_ops.zeros_initializer())
+            moving_mean = variables.model_variable(
+                'moving_mean',
+                shape=params_shape,
+                dtype=variable_dtype,
+                initializer=moving_mean_initializer,
+                trainable=False,
+                collections=moving_mean_collections)
+            moving_variance_collections = utils.get_variable_collections(
+                variables_collections, 'moving_variance')
+            moving_variance_initializer = param_initializers.get(
+                'moving_variance', init_ops.ones_initializer())
+            moving_variance = variables.model_variable(
+                'moving_variance',
+                shape=params_shape,
+                dtype=variable_dtype,
+                initializer=moving_variance_initializer,
+                trainable=False,
+                collections=moving_variance_collections)
+
+        def _fused_batch_norm_training():
+            return nn.fused_batch_norm(
+                inputs, gamma, beta, epsilon=epsilon, data_format=data_format)
+
+        def _fused_batch_norm_inference():
+            return nn.fused_batch_norm(
+                inputs,
+                gamma,
+                beta,
+                mean=moving_mean,
+                variance=moving_variance,
+                epsilon=epsilon,
+                is_training=False,
+                data_format=data_format)
+
+        outputs, mean, variance = utils.smart_cond(is_training,
+                                                   _fused_batch_norm_training,
+                                                   _fused_batch_norm_inference)
+
+        # If `is_training` doesn't have a constant value, because it is a `Tensor`,
+        # a `Variable` or `Placeholder` then is_training_value will be None and
+        # `need_updates` will be true.
+        is_training_value = utils.constant_value(is_training)
+        need_updates = is_training_value is None or is_training_value
+        if need_updates:
+            if updates_collections is None:
+                def no_updates(): return outputs
+
+                def _force_updates():
+                    """Internal function forces updates moving_vars if is_training."""
+                    update_moving_mean = moving_averages.assign_moving_average(
+                        moving_mean, mean, decay, zero_debias=zero_debias_moving_mean)
+                    update_moving_variance = moving_averages.assign_moving_average(
+                        moving_variance, variance, decay, zero_debias=False)
+                    with ops.control_dependencies(
+                            [update_moving_mean, update_moving_variance]):
+                        return array_ops.identity(outputs)
+
+                outputs = utils.smart_cond(
+                    is_training, _force_updates, no_updates)
+            else:
+                def moving_vars_fn(): return (moving_mean, moving_variance)
+
+                def _delay_updates():
+                    """Internal function that delay updates moving_vars if is_training."""
+                    update_moving_mean = moving_averages.assign_moving_average(
+                        moving_mean, mean, decay, zero_debias=zero_debias_moving_mean)
+                    update_moving_variance = moving_averages.assign_moving_average(
+                        moving_variance, variance, decay, zero_debias=False)
+                    return update_moving_mean, update_moving_variance
+
+                update_mean, update_variance = utils.smart_cond(is_training,
+                                                                _delay_updates,
+                                                                moving_vars_fn)
+                ops.add_to_collections(updates_collections, update_mean)
+                ops.add_to_collections(updates_collections, update_variance)
+
+        outputs.set_shape(inputs_shape)
+
+        if original_shape.ndims == 2:
+            def infer_static_shape(t):
+                """Infer the static shape of t.
+
+                Args:
+                  t: the input tensor.
+
+                Returns: a list of dimensions if it can be used as the target shape of a
+                  reshape. None if t's rank is unknown or t has more than one unknown
+                  dimensions.
+                """
+                if not t.shape.dims:
+                    return None
+
+                dims = t.shape.as_list()
+                num_nones = 0
+                for i, dim in enumerate(dims):
+                    if dim is None:
+                        num_nones += 1
+                        dims[i] = -1
+                if num_nones > 1:
+                    return None
+
+                return dims
+
+            # Use the static shape of original_inputs if possible so the graph can be
+            # better optimized.
+            target_shape = infer_static_shape(original_inputs)
+            if target_shape:
+                outputs = array_ops.reshape(outputs, target_shape)
+            else:
+                outputs = array_ops.reshape(
+                    outputs, array_ops.shape(original_inputs))
+
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def batch_norm(inputs,
+               decay=0.999,
+               center=True,
+               scale=False,
+               epsilon=0.001,
+               activation_fn=None,
+               param_initializers=None,
+               param_regularizers=None,
+               updates_collections=ops.GraphKeys.UPDATE_OPS,
+               is_training=True,
+               reuse=None,
+               variables_collections=None,
+               outputs_collections=None,
+               trainable=True,
+               batch_weights=None,
+               fused=None,
+               data_format=DATA_FORMAT_NHWC,
+               zero_debias_moving_mean=False,
+               scope=None,
+               renorm=False,
+               renorm_clipping=None,
+               renorm_decay=0.99,
+               adjustment=None):
+    """Adds a Batch Normalization layer from http://arxiv.org/abs/1502.03167.
+
+      "Batch Normalization: Accelerating Deep Network Training by Reducing
+      Internal Covariate Shift"
+
+      Sergey Ioffe, Christian Szegedy
+
+    Can be used as a normalizer function for conv2d and fully_connected. The
+    normalization is over all but the last dimension if `data_format` is `NHWC`
+    and all but the second dimension if `data_format` is `NCHW`.  In case of a 2D
+    tensor this corresponds to the batch dimension, while in case of a 4D tensor
+    this
+    corresponds to the batch and space dimensions.
+
+    Note: when training, the moving_mean and moving_variance need to be updated.
+    By default the update ops are placed in `tf.GraphKeys.UPDATE_OPS`, so they
+    need to be added as a dependency to the `train_op`. For example:
+
+    ```python
+      update_ops = tf.compat.v1.get_collection(tf.GraphKeys.UPDATE_OPS)
+      with tf.control_dependencies(update_ops):
+        train_op = optimizer.minimize(loss)
+    ```
+
+    One can set updates_collections=None to force the updates in place, but that
+    can have a speed penalty, especially in distributed settings.
+
+    Args:
+      inputs: A tensor with 2 or more dimensions, where the first dimension has
+        `batch_size`. The normalization is over all but the last dimension if
+        `data_format` is `NHWC` and the second dimension if `data_format` is
+        `NCHW`.
+      decay: Decay for the moving average. Reasonable values for `decay` are close
+        to 1.0, typically in the multiple-nines range: 0.999, 0.99, 0.9, etc.
+          Lower `decay` value (recommend trying `decay`=0.9) if model experiences
+          reasonably good training performance but poor validation and/or test
+          performance. Try zero_debias_moving_mean=True for improved stability.
+      center: If True, add offset of `beta` to normalized tensor. If False, `beta`
+        is ignored.
+      scale: If True, multiply by `gamma`. If False, `gamma` is not used. When the
+        next layer is linear (also e.g. `nn.relu`), this can be disabled since the
+        scaling can be done by the next layer.
+      epsilon: Small float added to variance to avoid dividing by zero.
+      activation_fn: Activation function, default set to None to skip it and
+        maintain a linear activation.
+      param_initializers: Optional initializers for beta, gamma, moving mean and
+        moving variance.
+      param_regularizers: Optional regularizer for beta and gamma.
+      updates_collections: Collections to collect the update ops for computation.
+        The updates_ops need to be executed with the train_op. If None, a control
+        dependency would be added to make sure the updates are computed in place.
+      is_training: Whether or not the layer is in training mode. In training mode
+        it would accumulate the statistics of the moments into `moving_mean` and
+        `moving_variance` using an exponential moving average with the given
+        `decay`. When it is not in training mode then it would use the values of
+        the `moving_mean` and the `moving_variance`.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional collections for the variables.
+      outputs_collections: Collections to add the outputs.
+      trainable: If `True` also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+      batch_weights: An optional tensor of shape `[batch_size]`, containing a
+        frequency weight for each batch item. If present, then the batch
+        normalization uses weighted mean and variance. (This can be used to
+        correct for bias in training example selection.)
+      fused: if `None` or `True`, use a faster, fused implementation if possible.
+        If `False`, use the system recommended implementation.
+      data_format: A string. `NHWC` (default) and `NCHW` are supported.
+      zero_debias_moving_mean: Use zero_debias for moving_mean. It creates a new
+        pair of variables 'moving_mean/biased' and 'moving_mean/local_step'.
+      scope: Optional scope for `variable_scope`.
+      renorm: Whether to use Batch Renormalization
+        (https://arxiv.org/abs/1702.03275). This adds extra variables during
+          training. The inference is the same for either value of this parameter.
+      renorm_clipping: A dictionary that may map keys 'rmax', 'rmin', 'dmax' to
+        scalar `Tensors` used to clip the renorm correction. The correction `(r,
+        d)` is used as `corrected_value = normalized_value * r + d`, with `r`
+        clipped to [rmin, rmax], and `d` to [-dmax, dmax]. Missing rmax, rmin,
+        dmax are set to inf, 0, inf, respectively.
+      renorm_decay: Momentum used to update the moving means and standard
+        deviations with renorm. Unlike `momentum`, this affects training and
+        should be neither too small (which would add noise) nor too large (which
+        would give stale estimates). Note that `decay` is still applied to get the
+        means and variances for inference.
+      adjustment: A function taking the `Tensor` containing the (dynamic) shape of
+        the input tensor and returning a pair (scale, bias) to apply to the
+        normalized values (before gamma and beta), only during training. For
+        example,
+          `adjustment = lambda shape: (
+            tf.random.uniform(shape[-1:], 0.93, 1.07),
+            tf.random.uniform(shape[-1:], -0.1, 0.1))` will scale the normalized
+              value by up to 7% up or down, then shift the result by up to 0.1
+              (with independent scaling and bias for each feature but shared
+              across all examples), and finally apply gamma and/or beta. If
+              `None`, no adjustment is applied.
+
+    Returns:
+      A `Tensor` representing the output of the operation.
+
+    Raises:
+      ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+      ValueError: If the rank of `inputs` is undefined.
+      ValueError: If rank or channels dimension of `inputs` is undefined.
+    """
+    if fused is None:
+        fused = True
+
+    # Only use _fused_batch_norm if all of the following three
+    # conditions are true:
+    # (1) fused is set True;
+    # (2) it is possible to use (currently it doesn't support batch weights,
+    #   renorm, and the case when rank is neither 2 nor 4);
+    # (3) it is used with zero_debias_moving_mean, or an input shape of rank 2,
+    #   or non-default updates_collections (not implemented in
+    #   normalization_layers.BatchNormalization yet); otherwise use the fused
+    #   implementation in normalization_layers.BatchNormalization.
+    inputs = ops.convert_to_tensor(inputs)
+    rank = inputs.get_shape().ndims
+    possible_to_fuse = (
+        batch_weights is None and not renorm and rank in [2, 4] and
+        adjustment is None)
+    if fused and possible_to_fuse and (
+            zero_debias_moving_mean or rank == 2 or
+            updates_collections is not ops.GraphKeys.UPDATE_OPS):
+        return _fused_batch_norm(
+            inputs,
+            decay=decay,
+            center=center,
+            scale=scale,
+            epsilon=epsilon,
+            activation_fn=activation_fn,
+            param_initializers=param_initializers,
+            param_regularizers=param_regularizers,
+            updates_collections=updates_collections,
+            is_training=is_training,
+            reuse=reuse,
+            variables_collections=variables_collections,
+            outputs_collections=outputs_collections,
+            trainable=trainable,
+            data_format=data_format,
+            zero_debias_moving_mean=zero_debias_moving_mean,
+            scope=scope)
+
+    if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+        raise ValueError('data_format has to be either NCHW or NHWC.')
+
+    layer_variable_getter = _build_variable_getter()
+    with variable_scope.variable_scope(
+        scope,
+        'BatchNorm', [inputs],
+        reuse=reuse,
+            custom_getter=layer_variable_getter) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+
+        # Determine whether we can use the core layer class.
+        if (batch_weights is None and
+            updates_collections is ops.GraphKeys.UPDATE_OPS and
+                not zero_debias_moving_mean):
+            # Use the core layer class.
+            axis = 1 if data_format == DATA_FORMAT_NCHW else -1
+            if not param_initializers:
+                param_initializers = {}
+            beta_initializer = param_initializers.get('beta',
+                                                      init_ops.zeros_initializer())
+            gamma_initializer = param_initializers.get('gamma',
+                                                       init_ops.ones_initializer())
+            moving_mean_initializer = param_initializers.get(
+                'moving_mean', init_ops.zeros_initializer())
+            moving_variance_initializer = param_initializers.get(
+                'moving_variance', init_ops.ones_initializer())
+            if not param_regularizers:
+                param_regularizers = {}
+            beta_regularizer = param_regularizers.get('beta')
+            gamma_regularizer = param_regularizers.get('gamma')
+            layer = normalization_layers.BatchNormalization(
+                axis=axis,
+                momentum=decay,
+                epsilon=epsilon,
+                center=center,
+                scale=scale,
+                beta_initializer=beta_initializer,
+                gamma_initializer=gamma_initializer,
+                moving_mean_initializer=moving_mean_initializer,
+                moving_variance_initializer=moving_variance_initializer,
+                beta_regularizer=beta_regularizer,
+                gamma_regularizer=gamma_regularizer,
+                trainable=trainable,
+                renorm=renorm,
+                renorm_clipping=renorm_clipping,
+                renorm_momentum=renorm_decay,
+                adjustment=adjustment,
+                name=sc.name,
+                _scope=sc,
+                _reuse=reuse,
+                fused=fused)
+            outputs = layer.apply(inputs, training=is_training)
+
+            # Add variables to collections.
+            _add_variable_to_collections(layer.moving_mean, variables_collections,
+                                         'moving_mean')
+            _add_variable_to_collections(layer.moving_variance, variables_collections,
+                                         'moving_variance')
+            if layer.beta is not None:
+                _add_variable_to_collections(
+                    layer.beta, variables_collections, 'beta')
+            if layer.gamma is not None:
+                _add_variable_to_collections(layer.gamma, variables_collections,
+                                             'gamma')
+
+            if activation_fn is not None:
+                outputs = activation_fn(outputs)
+            return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+        # Not supported by layer class: batch_weights argument,
+        # and custom updates_collections. In that case, use the legacy BN
+        # implementation.
+        # Custom updates collections are not supported because the update logic
+        # is different in this case, in particular w.r.t. "forced updates" and
+        # update op reuse.
+        if renorm:
+            raise ValueError('renorm is not supported with batch_weights, '
+                             'updates_collections or zero_debias_moving_mean')
+        inputs_shape = inputs.get_shape()
+        inputs_rank = inputs_shape.ndims
+        if inputs_rank is None:
+            raise ValueError('Inputs %s has undefined rank.' % inputs.name)
+        dtype = inputs.dtype.base_dtype
+        if batch_weights is not None:
+            batch_weights = ops.convert_to_tensor(batch_weights)
+            inputs_shape[0:1].assert_is_compatible_with(
+                batch_weights.get_shape())
+            # Reshape batch weight values so they broadcast across inputs.
+            nshape = [-1] + [1 for _ in range(inputs_rank - 1)]
+            batch_weights = array_ops.reshape(batch_weights, nshape)
+
+        if data_format == DATA_FORMAT_NCHW:
+            moments_axes = [0] + list(range(2, inputs_rank))
+            params_shape = inputs_shape[1:2]
+            # For NCHW format, rather than relying on implicit broadcasting, we
+            # explicitly reshape the params to params_shape_broadcast when computing
+            # the moments and the batch normalization.
+            params_shape_broadcast = list([1, inputs_shape.dims[1].value] +
+                                          [1 for _ in range(2, inputs_rank)])
+        else:
+            moments_axes = list(range(inputs_rank - 1))
+            params_shape = inputs_shape[-1:]
+            params_shape_broadcast = None
+        if not params_shape.is_fully_defined():
+            raise ValueError('Inputs %s has undefined channels dimension %s.' %
+                             (inputs.name, params_shape))
+
+        # Allocate parameters for the beta and gamma of the normalization.
+        beta, gamma = None, None
+        if not param_initializers:
+            param_initializers = {}
+        if center:
+            beta_collections = utils.get_variable_collections(variables_collections,
+                                                              'beta')
+            beta_initializer = param_initializers.get('beta',
+                                                      init_ops.zeros_initializer())
+            beta = variables.model_variable(
+                'beta',
+                shape=params_shape,
+                dtype=dtype,
+                initializer=beta_initializer,
+                collections=beta_collections,
+                trainable=trainable)
+        if scale:
+            gamma_collections = utils.get_variable_collections(
+                variables_collections, 'gamma')
+            gamma_initializer = param_initializers.get('gamma',
+                                                       init_ops.ones_initializer())
+            gamma = variables.model_variable(
+                'gamma',
+                shape=params_shape,
+                dtype=dtype,
+                initializer=gamma_initializer,
+                collections=gamma_collections,
+                trainable=trainable)
+
+        # Create moving_mean and moving_variance variables and add them to the
+        # appropriate collections. We disable variable partitioning while creating
+        # them, because assign_moving_average is not yet supported for partitioned
+        # variables (this needs to be handled carefully, as it may break
+        # the checkpoint backward compatibility).
+        with variable_scope.variable_scope(
+                variable_scope.get_variable_scope()) as local_scope:
+            local_scope.set_partitioner(None)
+            moving_mean_collections = utils.get_variable_collections(
+                variables_collections, 'moving_mean')
+            moving_mean_initializer = param_initializers.get(
+                'moving_mean', init_ops.zeros_initializer())
+            moving_mean = variables.model_variable(
+                'moving_mean',
+                shape=params_shape,
+                dtype=dtype,
+                initializer=moving_mean_initializer,
+                trainable=False,
+                collections=moving_mean_collections)
+            moving_variance_collections = utils.get_variable_collections(
+                variables_collections, 'moving_variance')
+            moving_variance_initializer = param_initializers.get(
+                'moving_variance', init_ops.ones_initializer())
+            moving_variance = variables.model_variable(
+                'moving_variance',
+                shape=params_shape,
+                dtype=dtype,
+                initializer=moving_variance_initializer,
+                trainable=False,
+                collections=moving_variance_collections)
+
+        # If `is_training` doesn't have a constant value, because it is a `Tensor`,
+        # a `Variable` or `Placeholder` then is_training_value will be None and
+        # `needs_moments` will be true.
+        is_training_value = utils.constant_value(is_training)
+        need_moments = is_training_value is None or is_training_value
+        if need_moments:
+            # Calculate the moments based on the individual batch.
+            if batch_weights is None:
+                if data_format == DATA_FORMAT_NCHW:
+                    mean, variance = nn.moments(
+                        inputs, moments_axes, keep_dims=True)
+                    mean = array_ops.reshape(mean, [-1])
+                    variance = array_ops.reshape(variance, [-1])
+                else:
+                    mean, variance = nn.moments(inputs, moments_axes)
+            else:
+                if data_format == DATA_FORMAT_NCHW:
+                    mean, variance = nn.weighted_moments(
+                        inputs, moments_axes, batch_weights, keepdims=True)
+                    mean = array_ops.reshape(mean, [-1])
+                    variance = array_ops.reshape(variance, [-1])
+                else:
+                    mean, variance = nn.weighted_moments(inputs, moments_axes,
+                                                         batch_weights)
+
+            def moving_vars_fn(): return (moving_mean, moving_variance)
+            if updates_collections is None:
+
+                def _force_updates():
+                    """Internal function forces updates moving_vars if is_training."""
+                    update_moving_mean = moving_averages.assign_moving_average(
+                        moving_mean, mean, decay, zero_debias=zero_debias_moving_mean)
+                    update_moving_variance = moving_averages.assign_moving_average(
+                        moving_variance, variance, decay, zero_debias=False)
+                    with ops.control_dependencies(
+                            [update_moving_mean, update_moving_variance]):
+                        return array_ops.identity(mean), array_ops.identity(variance)
+
+                mean, variance = utils.smart_cond(is_training, _force_updates,
+                                                  moving_vars_fn)
+            else:
+
+                def _delay_updates():
+                    """Internal function that delay updates moving_vars if is_training."""
+                    update_moving_mean = moving_averages.assign_moving_average(
+                        moving_mean, mean, decay, zero_debias=zero_debias_moving_mean)
+                    update_moving_variance = moving_averages.assign_moving_average(
+                        moving_variance, variance, decay, zero_debias=False)
+                    return update_moving_mean, update_moving_variance
+
+                update_mean, update_variance = utils.smart_cond(is_training,
+                                                                _delay_updates,
+                                                                moving_vars_fn)
+                ops.add_to_collections(updates_collections, update_mean)
+                ops.add_to_collections(updates_collections, update_variance)
+                # Use computed moments during training and moving_vars otherwise.
+
+                def vars_fn(): return (mean, variance)
+                mean, variance = utils.smart_cond(
+                    is_training, vars_fn, moving_vars_fn)
+        else:
+            mean, variance = moving_mean, moving_variance
+        if data_format == DATA_FORMAT_NCHW:
+            mean = array_ops.reshape(mean, params_shape_broadcast)
+            variance = array_ops.reshape(variance, params_shape_broadcast)
+            if beta is not None:
+                beta = array_ops.reshape(beta, params_shape_broadcast)
+            if gamma is not None:
+                gamma = array_ops.reshape(gamma, params_shape_broadcast)
+
+        # Compute batch_normalization.
+        outputs = nn.batch_normalization(inputs, mean, variance, beta, gamma,
+                                         epsilon)
+        outputs.set_shape(inputs_shape)
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def bias_add(inputs,
+             activation_fn=None,
+             initializer=init_ops.zeros_initializer(),
+             regularizer=None,
+             reuse=None,
+             variables_collections=None,
+             outputs_collections=None,
+             trainable=True,
+             data_format=DATA_FORMAT_NHWC,
+             scope=None):
+    """Adds a bias to the inputs.
+
+    Can be used as a normalizer function for conv2d and fully_connected.
+
+    Args:
+      inputs: A tensor of with at least rank 2 and value for the last dimension,
+        e.g. `[batch_size, depth]`, `[None, None, None, depth]`.
+      activation_fn: Activation function, default set to None to skip it and
+        maintain a linear activation.
+      initializer: An initializer for the bias, defaults to 0.
+      regularizer: A regularizer like the result of `l1_regularizer` or
+        `l2_regularizer`.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional collections for the variables.
+      outputs_collections: Collections to add the outputs.
+      trainable: If `True` also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+      data_format: A string. 'NHWC' and 'NCHW' are supported.
+      scope: Optional scope for variable_scope.
+
+    Returns:
+      A tensor representing the result of adding biases to the inputs.
+
+    Raises:
+      ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+      ValueError: If `data_format` is `NCHW` and rank of `inputs` is not 4.
+      ValueError: If the rank of `inputs` is undefined.
+      ValueError: If rank or `C` dimension of `inputs` is undefined.
+    """
+    if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+        raise ValueError('data_format has to be either NCHW or NHWC.')
+    with variable_scope.variable_scope(
+            scope, 'BiasAdd', [inputs], reuse=reuse) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        dtype = inputs.dtype.base_dtype
+        inputs_shape = inputs.get_shape()
+        inputs_rank = inputs_shape.ndims
+        if inputs_rank is None:
+            raise ValueError('Dims of shape must be known but is None')
+        elif inputs_rank != 4 and data_format == DATA_FORMAT_NCHW:
+            raise ValueError('Data format NCHW only supports 4D Tensor')
+        axis = 1 if data_format == DATA_FORMAT_NCHW else -1
+        num_features = inputs_shape.dims[axis].value
+        if num_features is None:
+            raise ValueError('`C` dimension must be known but is None')
+        biases_collections = utils.get_variable_collections(variables_collections,
+                                                            'biases')
+        biases = variables.model_variable(
+            'biases',
+            shape=[
+                num_features,
+            ],
+            dtype=dtype,
+            initializer=initializer,
+            regularizer=regularizer,
+            collections=biases_collections,
+            trainable=trainable)
+        outputs = nn.bias_add(inputs, biases, data_format=data_format)
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def convolution(inputs,
+                num_outputs,
+                kernel_size,
+                stride=1,
+                padding='SAME',
+                data_format=None,
+                rate=1,
+                activation_fn=nn.relu,
+                normalizer_fn=None,
+                normalizer_params=None,
+                weights_initializer=initializers.xavier_initializer(),
+                weights_regularizer=None,
+                biases_initializer=init_ops.zeros_initializer(),
+                biases_regularizer=None,
+                reuse=None,
+                variables_collections=None,
+                outputs_collections=None,
+                trainable=True,
+                scope=None,
+                conv_dims=None):
+    """Adds an N-D convolution followed by an optional batch_norm layer.
+
+    It is required that 1 <= N <= 3.
+
+    `convolution` creates a variable called `weights`, representing the
+    convolutional kernel, that is convolved (actually cross-correlated) with the
+    `inputs` to produce a `Tensor` of activations. If a `normalizer_fn` is
+    provided (such as `batch_norm`), it is then applied. Otherwise, if
+    `normalizer_fn` is None and a `biases_initializer` is provided then a `biases`
+    variable would be created and added the activations. Finally, if
+    `activation_fn` is not `None`, it is applied to the activations as well.
+
+    Performs atrous convolution with input stride/dilation rate equal to `rate`
+    if a value > 1 for any dimension of `rate` is specified.  In this case
+    `stride` values != 1 are not supported.
+
+    Args:
+      inputs: A Tensor of rank N+2 of shape `[batch_size] + input_spatial_shape +
+        [in_channels]` if data_format does not start with "NC" (default), or
+        `[batch_size, in_channels] + input_spatial_shape` if data_format starts
+        with "NC".
+      num_outputs: Integer, the number of output filters.
+      kernel_size: A sequence of N positive integers specifying the spatial
+        dimensions of the filters.  Can be a single integer to specify the same
+        value for all spatial dimensions.
+      stride: A sequence of N positive integers specifying the stride at which to
+        compute output.  Can be a single integer to specify the same value for all
+        spatial dimensions.  Specifying any `stride` value != 1 is incompatible
+        with specifying any `rate` value != 1.
+      padding: One of `"VALID"` or `"SAME"`.
+      data_format: A string or None.  Specifies whether the channel dimension of
+        the `input` and output is the last dimension (default, or if `data_format`
+        does not start with "NC"), or the second dimension (if `data_format`
+        starts with "NC").  For N=1, the valid values are "NWC" (default) and
+        "NCW".  For N=2, the valid values are "NHWC" (default) and "NCHW". For
+        N=3, the valid values are "NDHWC" (default) and "NCDHW".
+      rate: A sequence of N positive integers specifying the dilation rate to use
+        for atrous convolution.  Can be a single integer to specify the same value
+        for all spatial dimensions.  Specifying any `rate` value != 1 is
+        incompatible with specifying any `stride` value != 1.
+      activation_fn: Activation function. The default value is a ReLU function.
+        Explicitly set it to None to skip it and maintain a linear activation.
+      normalizer_fn: Normalization function to use instead of `biases`. If
+        `normalizer_fn` is provided then `biases_initializer` and
+        `biases_regularizer` are ignored and `biases` are not created nor added.
+        default set to None for no normalizer function
+      normalizer_params: Normalization function parameters.
+      weights_initializer: An initializer for the weights.
+      weights_regularizer: Optional regularizer for the weights.
+      biases_initializer: An initializer for the biases. If None skip biases.
+      biases_regularizer: Optional regularizer for the biases.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional list of collections for all the variables or
+        a dictionary containing a different list of collection per variable.
+      outputs_collections: Collection to add the outputs.
+      trainable: If `True` also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+      scope: Optional scope for `variable_scope`.
+      conv_dims: Optional convolution dimensionality, when set it would use the
+        corresponding convolution (e.g. 2 for Conv 2D, 3 for Conv 3D, ..). When
+        leaved to None it would select the convolution dimensionality based on the
+        input rank (i.e. Conv ND, with N = input_rank - 2).
+
+    Returns:
+      A tensor representing the output of the operation.
+
+    Raises:
+      ValueError: If `data_format` is invalid.
+      ValueError: Both 'rate' and `stride` are not uniformly 1.
+    """
+    if data_format not in [None, 'NWC', 'NCW', 'NHWC', 'NCHW', 'NDHWC', 'NCDHW']:
+        raise ValueError('Invalid data_format: %r' % (data_format,))
+
+    layer_variable_getter = _build_variable_getter({
+        'bias': 'biases',
+        'kernel': 'weights'
+    })
+
+    with variable_scope.variable_scope(
+            scope, 'Conv', [inputs], reuse=reuse,
+            custom_getter=layer_variable_getter) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        input_rank = inputs.get_shape().ndims
+
+        if conv_dims is not None and conv_dims + 2 != input_rank:
+            raise ValueError('Convolution expects input with rank %d, got %d' %
+                             (conv_dims + 2, input_rank))
+        if input_rank == 3:
+            layer_class = convolutional_layers.Convolution1D
+        elif input_rank == 4:
+            layer_class = convolutional_layers.Convolution2D
+        elif input_rank == 5:
+            layer_class = convolutional_layers.Convolution3D
+        else:
+            raise ValueError('Convolution not supported for input with rank',
+                             input_rank)
+
+        df = ('channels_first'
+              if data_format and data_format.startswith('NC') else 'channels_last')
+        layer = layer_class(
+            filters=num_outputs,
+            kernel_size=kernel_size,
+            strides=stride,
+            padding=padding,
+            data_format=df,
+            dilation_rate=rate,
+            activation=None,
+            use_bias=not normalizer_fn and biases_initializer,
+            kernel_initializer=weights_initializer,
+            bias_initializer=biases_initializer,
+            kernel_regularizer=weights_regularizer,
+            bias_regularizer=biases_regularizer,
+            activity_regularizer=None,
+            trainable=trainable,
+            name=sc.name,
+            dtype=inputs.dtype.base_dtype,
+            _scope=sc,
+            _reuse=reuse)
+        outputs = layer.apply(inputs)
+
+        # Add variables to collections.
+        _add_variable_to_collections(
+            layer.kernel, variables_collections, 'weights')
+        if layer.use_bias:
+            _add_variable_to_collections(
+                layer.bias, variables_collections, 'biases')
+
+        if normalizer_fn is not None:
+            normalizer_params = normalizer_params or {}
+            outputs = normalizer_fn(outputs, **normalizer_params)
+
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def convolution1d(inputs,
+                  num_outputs,
+                  kernel_size,
+                  stride=1,
+                  padding='SAME',
+                  data_format=None,
+                  rate=1,
+                  activation_fn=nn.relu,
+                  normalizer_fn=None,
+                  normalizer_params=None,
+                  weights_initializer=initializers.xavier_initializer(),
+                  weights_regularizer=None,
+                  biases_initializer=init_ops.zeros_initializer(),
+                  biases_regularizer=None,
+                  reuse=None,
+                  variables_collections=None,
+                  outputs_collections=None,
+                  trainable=True,
+                  scope=None):
+    return convolution(
+        inputs,
+        num_outputs,
+        kernel_size,
+        stride,
+        padding,
+        data_format,
+        rate,
+        activation_fn,
+        normalizer_fn,
+        normalizer_params,
+        weights_initializer,
+        weights_regularizer,
+        biases_initializer,
+        biases_regularizer,
+        reuse,
+        variables_collections,
+        outputs_collections,
+        trainable,
+        scope,
+        conv_dims=1)
+
+
+convolution1d.__doc__ = convolution.__doc__
+
+
+@add_arg_scope
+def convolution2d(inputs,
+                  num_outputs,
+                  kernel_size,
+                  stride=1,
+                  padding='SAME',
+                  data_format=None,
+                  rate=1,
+                  activation_fn=nn.relu,
+                  normalizer_fn=None,
+                  normalizer_params=None,
+                  weights_initializer=initializers.xavier_initializer(),
+                  weights_regularizer=None,
+                  biases_initializer=init_ops.zeros_initializer(),
+                  biases_regularizer=None,
+                  reuse=None,
+                  variables_collections=None,
+                  outputs_collections=None,
+                  trainable=True,
+                  scope=None):
+    return convolution(
+        inputs,
+        num_outputs,
+        kernel_size,
+        stride,
+        padding,
+        data_format,
+        rate,
+        activation_fn,
+        normalizer_fn,
+        normalizer_params,
+        weights_initializer,
+        weights_regularizer,
+        biases_initializer,
+        biases_regularizer,
+        reuse,
+        variables_collections,
+        outputs_collections,
+        trainable,
+        scope,
+        conv_dims=2)
+
+
+convolution2d.__doc__ = convolution.__doc__
+
+
+@add_arg_scope
+def convolution3d(inputs,
+                  num_outputs,
+                  kernel_size,
+                  stride=1,
+                  padding='SAME',
+                  data_format=None,
+                  rate=1,
+                  activation_fn=nn.relu,
+                  normalizer_fn=None,
+                  normalizer_params=None,
+                  weights_initializer=initializers.xavier_initializer(),
+                  weights_regularizer=None,
+                  biases_initializer=init_ops.zeros_initializer(),
+                  biases_regularizer=None,
+                  reuse=None,
+                  variables_collections=None,
+                  outputs_collections=None,
+                  trainable=True,
+                  scope=None):
+    return convolution(
+        inputs,
+        num_outputs,
+        kernel_size,
+        stride,
+        padding,
+        data_format,
+        rate,
+        activation_fn,
+        normalizer_fn,
+        normalizer_params,
+        weights_initializer,
+        weights_regularizer,
+        biases_initializer,
+        biases_regularizer,
+        reuse,
+        variables_collections,
+        outputs_collections,
+        trainable,
+        scope,
+        conv_dims=3)
+
+
+convolution3d.__doc__ = convolution.__doc__
+
+
+@add_arg_scope
+def convolution2d_in_plane(
+        inputs,
+        kernel_size,
+        stride=1,
+        padding='SAME',
+        activation_fn=nn.relu,
+        normalizer_fn=None,
+        normalizer_params=None,
+        weights_initializer=initializers.xavier_initializer(),
+        weights_regularizer=None,
+        biases_initializer=init_ops.zeros_initializer(),
+        biases_regularizer=None,
+        reuse=None,
+        variables_collections=None,
+        outputs_collections=None,
+        trainable=True,
+        scope=None):
+    """Performs the same in-plane convolution to each channel independently.
+
+    This is useful for performing various simple channel-independent convolution
+    operations such as image gradients:
+
+      image = tf.constant(..., shape=(16, 240, 320, 3))
+      vert_gradients = layers.conv2d_in_plane(image,
+                                              kernel=[1, -1],
+                                              kernel_size=[2, 1])
+      horz_gradients = layers.conv2d_in_plane(image,
+                                              kernel=[1, -1],
+                                              kernel_size=[1, 2])
+
+    Args:
+      inputs: A 4-D tensor with dimensions [batch_size, height, width, channels].
+      kernel_size: A list of length 2 holding the [kernel_height, kernel_width] of
+        of the pooling. Can be an int if both values are the same.
+      stride: A list of length 2 `[stride_height, stride_width]`. Can be an int if
+        both strides are the same. Note that presently both strides must have the
+        same value.
+      padding: The padding type to use, either 'SAME' or 'VALID'.
+      activation_fn: Activation function. The default value is a ReLU function.
+        Explicitly set it to None to skip it and maintain a linear activation.
+      normalizer_fn: Normalization function to use instead of `biases`. If
+        `normalizer_fn` is provided then `biases_initializer` and
+        `biases_regularizer` are ignored and `biases` are not created nor added.
+        default set to None for no normalizer function
+      normalizer_params: Normalization function parameters.
+      weights_initializer: An initializer for the weights.
+      weights_regularizer: Optional regularizer for the weights.
+      biases_initializer: An initializer for the biases. If None skip biases.
+      biases_regularizer: Optional regularizer for the biases.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional list of collections for all the variables or
+        a dictionary containing a different list of collection per variable.
+      outputs_collections: Collection to add the outputs.
+      trainable: If `True` also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+      scope: Optional scope for `variable_scope`.
+
+    Returns:
+      A `Tensor` representing the output of the operation.
+    """
+    with variable_scope.variable_scope(
+            scope, 'ConvInPlane', [inputs], reuse=reuse) as sc:
+        dtype = inputs.dtype.base_dtype
+        kernel_h, kernel_w = utils.two_element_tuple(kernel_size)
+        stride_h, stride_w = utils.two_element_tuple(stride)
+        num_filters_in = utils.last_dimension(inputs.get_shape(), min_rank=4)
+        weights_shape = [kernel_h, kernel_w, 1, 1]
+        weights_collections = utils.get_variable_collections(
+            variables_collections, 'weights')
+        weights = variables.model_variable(
+            'weights',
+            shape=weights_shape,
+            dtype=dtype,
+            initializer=weights_initializer,
+            regularizer=weights_regularizer,
+            collections=weights_collections,
+            trainable=trainable)
+        depthwise_weights = array_ops.tile(weights, [1, 1, num_filters_in, 1])
+        outputs = nn.depthwise_conv2d(inputs, depthwise_weights,
+                                      [1, stride_h, stride_w, 1], padding)
+        if normalizer_fn is not None:
+            normalizer_params = normalizer_params or {}
+            outputs = normalizer_fn(outputs, **normalizer_params)
+        else:
+            if biases_initializer is not None:
+                biases_collections = utils.get_variable_collections(
+                    variables_collections, 'biases')
+                biases = variables.model_variable(
+                    'biases',
+                    shape=[
+                        num_filters_in,
+                    ],
+                    dtype=dtype,
+                    initializer=biases_initializer,
+                    regularizer=biases_regularizer,
+                    collections=biases_collections,
+                    trainable=trainable)
+                outputs = nn.bias_add(outputs, biases)
+
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def convolution2d_transpose(
+        inputs,
+        num_outputs,
+        kernel_size,
+        stride=1,
+        padding='SAME',
+        data_format=DATA_FORMAT_NHWC,
+        activation_fn=nn.relu,
+        normalizer_fn=None,
+        normalizer_params=None,
+        weights_initializer=initializers.xavier_initializer(),
+        weights_regularizer=None,
+        biases_initializer=init_ops.zeros_initializer(),
+        biases_regularizer=None,
+        reuse=None,
+        variables_collections=None,
+        outputs_collections=None,
+        trainable=True,
+        scope=None):
+    """Adds a convolution2d_transpose with an optional batch normalization layer.
+
+    The function creates a variable called `weights`, representing the
+    kernel, that is convolved with the input. If `normalizer_fn` is `None`, a
+    second variable called 'biases' is added to the result of the operation.
+
+    Args:
+      inputs: A 4-D `Tensor` of type `float` and shape `[batch, height, width,
+        in_channels]` for `NHWC` data format or `[batch, in_channels, height,
+        width]` for `NCHW` data format.
+      num_outputs: Integer, the number of output filters.
+      kernel_size: A list of length 2 holding the [kernel_height, kernel_width] of
+        of the filters. Can be an int if both values are the same.
+      stride: A list of length 2: [stride_height, stride_width]. Can be an int if
+        both strides are the same.  Note that presently both strides must have the
+        same value.
+      padding: One of 'VALID' or 'SAME'.
+      data_format: A string. `NHWC` (default) and `NCHW` are supported.
+      activation_fn: Activation function. The default value is a ReLU function.
+        Explicitly set it to None to skip it and maintain a linear activation.
+      normalizer_fn: Normalization function to use instead of `biases`. If
+        `normalizer_fn` is provided then `biases_initializer` and
+        `biases_regularizer` are ignored and `biases` are not created nor added.
+        default set to None for no normalizer function
+      normalizer_params: Normalization function parameters.
+      weights_initializer: An initializer for the weights.
+      weights_regularizer: Optional regularizer for the weights.
+      biases_initializer: An initializer for the biases. If None skip biases.
+      biases_regularizer: Optional regularizer for the biases.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional list of collections for all the variables or
+        a dictionary containing a different list of collection per variable.
+      outputs_collections: Collection to add the outputs.
+      trainable: Whether or not the variables should be trainable or not.
+      scope: Optional scope for variable_scope.
+
+    Returns:
+      A tensor representing the output of the operation.
+
+    Raises:
+      ValueError: If 'kernel_size' is not a list of length 2.
+      ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+      ValueError: If `C` dimension of `inputs` is None.
+    """
+    layer_variable_getter = _build_variable_getter({
+        'bias': 'biases',
+        'kernel': 'weights'
+    })
+
+    with variable_scope.variable_scope(
+        scope,
+        'Conv2d_transpose', [inputs],
+        reuse=reuse,
+            custom_getter=layer_variable_getter) as sc:
+        if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+            raise ValueError('data_format has to be either NCHW or NHWC.')
+
+        inputs = ops.convert_to_tensor(inputs)
+
+        df = ('channels_first'
+              if data_format and data_format.startswith('NC') else 'channels_last')
+        layer = convolutional_layers.Convolution2DTranspose(
+            filters=num_outputs,
+            kernel_size=kernel_size,
+            strides=stride,
+            padding=padding,
+            data_format=df,
+            activation=None,
+            use_bias=not normalizer_fn and biases_initializer,
+            kernel_initializer=weights_initializer,
+            bias_initializer=biases_initializer,
+            kernel_regularizer=weights_regularizer,
+            bias_regularizer=biases_regularizer,
+            activity_regularizer=None,
+            trainable=trainable,
+            name=sc.name,
+            dtype=inputs.dtype.base_dtype,
+            _scope=sc,
+            _reuse=reuse)
+        outputs = layer.apply(inputs)
+
+        # Add variables to collections.
+        _add_variable_to_collections(
+            layer.kernel, variables_collections, 'weights')
+        if layer.bias is not None:
+            _add_variable_to_collections(
+                layer.bias, variables_collections, 'biases')
+
+        if normalizer_fn is not None:
+            normalizer_params = normalizer_params or {}
+            outputs = normalizer_fn(outputs, **normalizer_params)
+
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def convolution3d_transpose(
+        inputs,
+        num_outputs,
+        kernel_size,
+        stride=1,
+        padding='SAME',
+        data_format=DATA_FORMAT_NDHWC,
+        activation_fn=nn.relu,
+        normalizer_fn=None,
+        normalizer_params=None,
+        weights_initializer=initializers.xavier_initializer(),
+        weights_regularizer=None,
+        biases_initializer=init_ops.zeros_initializer(),
+        biases_regularizer=None,
+        reuse=None,
+        variables_collections=None,
+        outputs_collections=None,
+        trainable=True,
+        scope=None):
+    """Adds a convolution3d_transpose with an optional batch normalization layer.
+
+    The function creates a variable called `weights`, representing the
+    kernel, that is convolved with the input. If `batch_norm_params` is `None`, a
+    second variable called 'biases' is added to the result of the operation.
+    Args:
+      inputs: A 5-D `Tensor` of type `float` and shape `[batch, depth, height,
+        width, in_channels]` for `NDHWC` data format or `[batch, in_channels,
+        depth, height, width]` for `NCDHW` data format.
+      num_outputs: Integer, the number of output filters.
+      kernel_size: A list of length 3 holding the [kernel_depth, kernel_height,
+        kernel_width] of the filters. Can be an int if both values are the same.
+      stride: A list of length 3: [stride_depth, stride_height, stride_width]. Can
+        be an int if both strides are the same.  Note that presently both strides
+        must have the same value.
+      padding: One of 'VALID' or 'SAME'.
+      data_format: A string. `NDHWC` (default) and `NCDHW` are supported.
+      activation_fn: Activation function. The default value is a ReLU function.
+        Explicitly set it to None to skip it and maintain a linear activation.
+      normalizer_fn: Normalization function to use instead of `biases`. If
+        `normalizer_fn` is provided then `biases_initializer` and
+        `biases_regularizer` are ignored and `biases` are not created nor added.
+        default set to None for no normalizer function
+      normalizer_params: Normalization function parameters.
+      weights_initializer: An initializer for the weights.
+      weights_regularizer: Optional regularizer for the weights.
+      biases_initializer: An initializer for the biases. If None skip biases.
+      biases_regularizer: Optional regularizer for the biases.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional list of collections for all the variables or
+        a dictionary containing a different list of collection per variable.
+      outputs_collections: Collection to add the outputs.
+      trainable: Whether or not the variables should be trainable or not.
+      scope: Optional scope for variable_scope.
+
+    Returns:
+      A tensor representing the output of the operation.
+    Raises:
+      ValueError: If 'kernel_size' is not a list of length 3.
+      ValueError: If `data_format` is neither `NDHWC` nor `NCDHW`.
+      ValueError: If `C` dimension of `inputs` is None.
+    """
+    layer_variable_getter = _build_variable_getter({
+        'bias': 'biases',
+        'kernel': 'weights'
+    })
+
+    with variable_scope.variable_scope(
+        scope,
+        'Conv3d_transpose', [inputs],
+        reuse=reuse,
+            custom_getter=layer_variable_getter) as sc:
+        if data_format not in (DATA_FORMAT_NCDHW, DATA_FORMAT_NDHWC):
+            raise ValueError('data_format has to be either NCDHW or NDHWC.')
+
+        inputs = ops.convert_to_tensor(inputs)
+
+        df = ('channels_first'
+              if data_format and data_format.startswith('NC') else 'channels_last')
+        layer = convolutional_layers.Convolution3DTranspose(
+            filters=num_outputs,
+            kernel_size=kernel_size,
+            strides=stride,
+            padding=padding,
+            data_format=df,
+            activation=None,
+            use_bias=not normalizer_fn and biases_initializer,
+            kernel_initializer=weights_initializer,
+            bias_initializer=biases_initializer,
+            kernel_regularizer=weights_regularizer,
+            bias_regularizer=biases_regularizer,
+            activity_regularizer=None,
+            trainable=trainable,
+            name=sc.name,
+            dtype=inputs.dtype.base_dtype,
+            _scope=sc,
+            _reuse=reuse)
+        outputs = layer.apply(inputs)
+
+        # Add variables to collections.
+        _add_variable_to_collections(
+            layer.kernel, variables_collections, 'weights')
+        if layer.bias is not None:
+            _add_variable_to_collections(
+                layer.bias, variables_collections, 'biases')
+
+        if normalizer_fn is not None:
+            normalizer_params = normalizer_params or {}
+            outputs = normalizer_fn(outputs, **normalizer_params)
+
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def dense_to_sparse(tensor, eos_token=0, outputs_collections=None, scope=None):
+    """Converts a dense tensor into a sparse tensor.
+
+    An example use would be to convert dense labels to sparse ones
+    so that they can be fed to the ctc_loss.
+
+    Args:
+       tensor: An `int` `Tensor` to be converted to a `Sparse`.
+       eos_token: An integer. It is part of the target label that signifies the
+         end of a sentence.
+       outputs_collections: Collection to add the outputs.
+       scope: Optional scope for name_scope.
+    """
+    with variable_scope.variable_scope(scope, 'dense_to_sparse', [tensor]) as sc:
+        tensor = ops.convert_to_tensor(tensor)
+        indices = array_ops.where(
+            math_ops.not_equal(tensor, constant_op.constant(eos_token,
+                                                            tensor.dtype)))
+        values = array_ops.gather_nd(tensor, indices)
+        shape = array_ops.shape(tensor, out_type=dtypes.int64)
+        outputs = sparse_tensor.SparseTensor(indices, values, shape)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def dropout(inputs,
+            keep_prob=0.5,
+            noise_shape=None,
+            is_training=True,
+            outputs_collections=None,
+            scope=None,
+            seed=None):
+    """Returns a dropout op applied to the input.
+
+    With probability `keep_prob`, outputs the input element scaled up by
+    `1 / keep_prob`, otherwise outputs `0`.  The scaling is so that the expected
+    sum is unchanged.
+
+    Args:
+      inputs: The tensor to pass to the nn.dropout op.
+      keep_prob: A scalar `Tensor` with the same type as x. The probability that
+        each element is kept.
+      noise_shape: A 1-D `Tensor` of type `int32`, representing the shape for
+        randomly generated keep/drop flags.
+      is_training: A bool `Tensor` indicating whether or not the model is in
+        training mode. If so, dropout is applied and values scaled. Otherwise,
+        inputs is returned.
+      outputs_collections: Collection to add the outputs.
+      scope: Optional scope for name_scope.
+      seed: A Python integer. Used to create random seeds. See
+        `tf.compat.v1.set_random_seed` for behavior.
+
+    Returns:
+      A tensor representing the output of the operation.
+    """
+    with variable_scope.variable_scope(
+            scope, 'Dropout', [inputs], custom_getter=_model_variable_getter) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        layer = core_layers.Dropout(
+            rate=1 - keep_prob,
+            noise_shape=noise_shape,
+            seed=seed,
+            name=sc.name,
+            _scope=sc)
+        outputs = layer.apply(inputs, training=is_training)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def flatten(inputs, outputs_collections=None, scope=None):
+    """Flattens the input while maintaining the batch_size.
+
+      Assumes that the first dimension represents the batch.
+
+    Args:
+      inputs: A tensor of size [batch_size, ...].
+      outputs_collections: Collection to add the outputs.
+      scope: Optional scope for name_scope.
+
+    Returns:
+      A flattened tensor with shape [batch_size, k].
+    Raises:
+      ValueError: If inputs rank is unknown or less than 2.
+    """
+    with ops.name_scope(scope, 'Flatten', [inputs]) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        outputs = core_layers.flatten(inputs)
+        return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+def _sparse_inner_flatten(inputs, new_rank):
+    """Helper function for `inner_flatten`."""
+    inputs_rank = inputs.dense_shape.get_shape().as_list()[0]
+    if inputs_rank < new_rank:
+        raise ValueError(
+            'Inputs has rank less than new_rank. {} must have rank at least'
+            ' {}. Received rank {}, shape {}'.format(inputs, new_rank, inputs_rank,
+                                                     inputs.get_shape()))
+
+    outer_dimensions = inputs.dense_shape[:new_rank - 1]
+    inner_dimensions = inputs.dense_shape[new_rank - 1:]
+    new_shape = array_ops.concat(
+        (outer_dimensions, [math_ops.reduce_prod(inner_dimensions)]), 0)
+    flattened = sparse_ops.sparse_reshape(inputs, new_shape)
+    return flattened
+
+
+def _dense_inner_flatten(inputs, new_rank):
+    """Helper function for `inner_flatten`."""
+    rank_assertion = check_ops.assert_rank_at_least(
+        inputs, new_rank, message='inputs has rank less than new_rank')
+    with ops.control_dependencies([rank_assertion]):
+        outer_dimensions = array_ops.strided_slice(
+            array_ops.shape(inputs), [0], [new_rank - 1])
+        new_shape = array_ops.concat((outer_dimensions, [-1]), 0)
+        reshaped = array_ops.reshape(inputs, new_shape)
+
+    # if `new_rank` is an integer, try to calculate new shape.
+    if isinstance(new_rank, six.integer_types):
+        static_shape = inputs.get_shape()
+        if static_shape is not None and static_shape.dims is not None:
+            static_shape = static_shape.as_list()
+            static_outer_dims = static_shape[:new_rank - 1]
+            static_inner_dims = static_shape[new_rank - 1:]
+            flattened_dimension = 1
+            for inner_dim in static_inner_dims:
+                if inner_dim is None:
+                    flattened_dimension = None
+                    break
+                flattened_dimension *= inner_dim
+            reshaped.set_shape(static_outer_dims + [flattened_dimension])
+    return reshaped
+
+
+@add_arg_scope
+def _inner_flatten(inputs, new_rank, output_collections=None, scope=None):
+    """Flattens inner dimensions of `inputs`, returns a Tensor with `new_rank`.
+
+    For example:
+    '''
+        x = tf.random.uniform(shape=[1, 2, 3, 4, 5, 6])
+        y = _inner_flatten(x, 4)
+        assert y.get_shape().as_list() == [1, 2, 3, (4 * 5 * 6)]
+    '''
+    This layer will fail at run time if `new_rank` is greater than the current
+    rank of `inputs`.
+
+    Args:
+      inputs: A `Tensor` or `SparseTensor`.
+      new_rank: The desired rank of the returned `Tensor` or `SparseTensor`.
+      output_collections: Collection to which the outputs will be added.
+      scope: Optional scope for `name_scope`.
+
+    Returns:
+      A `Tensor` or `SparseTensor` containing the same values as `inputs`, but
+      with innermost dimensions flattened to obtain rank `new_rank`.
+
+    Raises:
+      TypeError: `inputs` is not a `Tensor` or `SparseTensor`.
+    """
+    with ops.name_scope(scope, 'InnerFlatten', [inputs, new_rank]) as sc:
+        if isinstance(inputs, sparse_tensor.SparseTensor):
+            flattened = _sparse_inner_flatten(inputs, new_rank)
+        else:
+            inputs = ops.convert_to_tensor(inputs)
+            flattened = _dense_inner_flatten(inputs, new_rank)
+    return utils.collect_named_outputs(output_collections, sc, flattened)
+
+
+def _model_variable_getter(
+        getter,
+        name,
+        shape=None,
+        dtype=None,
+        initializer=None,
+        regularizer=None,
+        trainable=True,
+        collections=None,
+        caching_device=None,
+        partitioner=None,
+        rename=None,
+        use_resource=None,
+        synchronization=tf_variables.VariableSynchronization.AUTO,
+        aggregation=tf_variables.VariableAggregation.NONE,
+        **_):
+    """Getter that uses model_variable for compatibility with core layers."""
+    short_name = name.split('/')[-1]
+    if rename and short_name in rename:
+        name_components = name.split('/')
+        name_components[-1] = rename[short_name]
+        name = '/'.join(name_components)
+    return variables.model_variable(
+        name,
+        shape=shape,
+        dtype=dtype,
+        initializer=initializer,
+        regularizer=regularizer,
+        collections=collections,
+        trainable=trainable,
+        caching_device=caching_device,
+        partitioner=partitioner,
+        custom_getter=getter,
+        use_resource=use_resource,
+        synchronization=synchronization,
+        aggregation=aggregation)
+
+
+def _build_variable_getter(rename=None):
+    """Build a model variable getter that respects scope getter and renames."""
+
+    # VariableScope will nest the getters
+    def layer_variable_getter(getter, *args, **kwargs):
+        kwargs['rename'] = rename
+        return _model_variable_getter(getter, *args, **kwargs)
+
+    return layer_variable_getter
+
+
+def _add_variable_to_collections(variable, collections_set, collections_name):
+    """Adds variable (or all its parts) to all collections with that name."""
+    collections = utils.get_variable_collections(collections_set,
+                                                 collections_name) or []
+    variables_list = [variable]
+    if isinstance(variable, tf_variables.PartitionedVariable):
+        variables_list = [v for v in variable]
+    for collection in collections:
+        for var in variables_list:
+            if var not in ops.get_collection(collection):
+                ops.add_to_collection(collection, var)
+
+
+@add_arg_scope
+def fully_connected(inputs,
+                    num_outputs,
+                    activation_fn=nn.relu,
+                    normalizer_fn=None,
+                    normalizer_params=None,
+                    weights_initializer=initializers.xavier_initializer(),
+                    weights_regularizer=None,
+                    biases_initializer=init_ops.zeros_initializer(),
+                    biases_regularizer=None,
+                    reuse=None,
+                    variables_collections=None,
+                    outputs_collections=None,
+                    trainable=True,
+                    scope=None):
+    """Adds a fully connected layer.
+
+    `fully_connected` creates a variable called `weights`, representing a fully
+    connected weight matrix, which is multiplied by the `inputs` to produce a
+    `Tensor` of hidden units. If a `normalizer_fn` is provided (such as
+    `batch_norm`), it is then applied. Otherwise, if `normalizer_fn` is
+    None and a `biases_initializer` is provided then a `biases` variable would be
+    created and added the hidden units. Finally, if `activation_fn` is not `None`,
+    it is applied to the hidden units as well.
+
+    Note: that if `inputs` have a rank greater than 2, then `inputs` is flattened
+    prior to the initial matrix multiply by `weights`.
+
+    Args:
+      inputs: A tensor of at least rank 2 and static value for the last dimension;
+        i.e. `[batch_size, depth]`, `[None, None, None, channels]`.
+      num_outputs: Integer or long, the number of output units in the layer.
+      activation_fn: Activation function. The default value is a ReLU function.
+        Explicitly set it to None to skip it and maintain a linear activation.
+      normalizer_fn: Normalization function to use instead of `biases`. If
+        `normalizer_fn` is provided then `biases_initializer` and
+        `biases_regularizer` are ignored and `biases` are not created nor added.
+        default set to None for no normalizer function
+      normalizer_params: Normalization function parameters.
+      weights_initializer: An initializer for the weights.
+      weights_regularizer: Optional regularizer for the weights.
+      biases_initializer: An initializer for the biases. If None skip biases.
+      biases_regularizer: Optional regularizer for the biases.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional list of collections for all the variables or
+        a dictionary containing a different list of collections per variable.
+      outputs_collections: Collection to add the outputs.
+      trainable: If `True` also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+      scope: Optional scope for variable_scope.
+
+    Returns:
+       The tensor variable representing the result of the series of operations.
+
+    Raises:
+      ValueError: If x has rank less than 2 or if its last dimension is not set.
+    """
+    if not isinstance(num_outputs, six.integer_types):
+        raise ValueError('num_outputs type should be one of %s, got %s.' %
+                         (list(six.integer_types), type(num_outputs)))
+
+    layer_variable_getter = _build_variable_getter({
+        'bias': 'biases',
+        'kernel': 'weights'
+    })
+
+    with variable_scope.variable_scope(
+        scope,
+        'fully_connected', [inputs],
+        reuse=reuse,
+            custom_getter=layer_variable_getter) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        layer = core_layers.Dense(
+            units=num_outputs,
+            activation=None,
+            use_bias=not normalizer_fn and biases_initializer,
+            kernel_initializer=weights_initializer,
+            bias_initializer=biases_initializer,
+            kernel_regularizer=weights_regularizer,
+            bias_regularizer=biases_regularizer,
+            activity_regularizer=None,
+            trainable=trainable,
+            name=sc.name,
+            dtype=inputs.dtype.base_dtype,
+            _scope=sc,
+            _reuse=reuse)
+        outputs = layer.apply(inputs)
+
+        # Add variables to collections.
+        _add_variable_to_collections(
+            layer.kernel, variables_collections, 'weights')
+        if layer.bias is not None:
+            _add_variable_to_collections(
+                layer.bias, variables_collections, 'biases')
+
+        # Apply normalizer function / layer.
+        if normalizer_fn is not None:
+            if not normalizer_params:
+                normalizer_params = {}
+            outputs = normalizer_fn(outputs, **normalizer_params)
+
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+class GDN(base.Layer):
+    """Generalized divisive normalization layer.
+
+    Based on the papers:
+
+      "Density Modeling of Images using a Generalized Normalization
+      Transformation"
+
+      Johannes Ballé, Valero Laparra, Eero P. Simoncelli
+
+      https://arxiv.org/abs/1511.06281
+
+      "End-to-end Optimized Image Compression"
+
+      Johannes Ballé, Valero Laparra, Eero P. Simoncelli
+
+      https://arxiv.org/abs/1611.01704
+
+    Implements an activation function that is essentially a multivariate
+    generalization of a particular sigmoid-type function:
+
+    ```
+    y[i] = x[i] / sqrt(beta[i] + sum_j(gamma[j, i] * x[j]))
+    ```
+
+    where `i` and `j` run over channels. This implementation never sums across
+    spatial dimensions. It is similar to local response normalization, but much
+    more flexible, as `beta` and `gamma` are trainable parameters.
+
+    Arguments:
+      inverse: If `False` (default), compute GDN response. If `True`, compute IGDN
+        response (one step of fixed point iteration to invert GDN; the division is
+        replaced by multiplication).
+      beta_min: Lower bound for beta, to prevent numerical error from causing
+        square root of zero or negative values.
+      gamma_init: The gamma matrix will be initialized as the identity matrix
+        multiplied with this value. If set to zero, the layer is effectively
+        initialized to the identity operation, since beta is initialized as one. A
+        good default setting is somewhere between 0 and 0.5.
+      reparam_offset: Offset added to the reparameterization of beta and gamma.
+        The reparameterization of beta and gamma as their square roots lets the
+        training slow down when their values are close to zero, which is desirable
+        as small values in the denominator can lead to a situation where gradient
+        noise on beta/gamma leads to extreme amounts of noise in the GDN
+        activations. However, without the offset, we would get zero gradients if
+        any elements of beta or gamma were exactly zero, and thus the training
+        could get stuck. To prevent this, we add this small constant. The default
+        value was empirically determined as a good starting point. Making it
+        bigger potentially leads to more gradient noise on the activations, making
+        it too small may lead to numerical precision issues.
+      data_format: Format of input tensor. Currently supports `'channels_first'`
+        and `'channels_last'`.
+      activity_regularizer: Regularizer function for the output.
+      trainable: Boolean, if `True`, also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+      name: String, the name of the layer. Layers with the same name will share
+        weights, but to avoid mistakes we require `reuse=True` in such cases.
+    Properties:
+      inverse: Boolean, whether GDN is computed (`True`) or IGDN (`False`).
+      data_format: Format of input tensor. Currently supports `'channels_first'`
+        and `'channels_last'`.
+      beta: The beta parameter as defined above (1D `Tensor`).
+      gamma: The gamma parameter as defined above (2D `Tensor`).
+    """
+
+    def __init__(self,
+                 inverse=False,
+                 beta_min=1e-6,
+                 gamma_init=.1,
+                 reparam_offset=2**-18,
+                 data_format='channels_last',
+                 activity_regularizer=None,
+                 trainable=True,
+                 name=None,
+                 **kwargs):
+        super(GDN, self).__init__(
+            trainable=trainable,
+            name=name,
+            activity_regularizer=activity_regularizer,
+            **kwargs)
+        self.inverse = inverse
+        self._beta_min = beta_min
+        self._gamma_init = gamma_init
+        self._reparam_offset = reparam_offset
+        self.data_format = data_format
+        self._channel_axis()  # trigger ValueError early
+        self.input_spec = input_spec.InputSpec(min_ndim=3, max_ndim=5)
+
+    def _channel_axis(self):
+        try:
+            return {'channels_first': 1, 'channels_last': -1}[self.data_format]
+        except KeyError:
+            raise ValueError('Unsupported `data_format` for GDN layer: {}.'.format(
+                self.data_format))
+
+    @staticmethod
+    def _lower_bound(inputs, bound, name=None):
+        """Same as tf.maximum, but with helpful gradient for inputs < bound.
+
+        The gradient is overwritten so that it is passed through if the input is not
+        hitting the bound. If it is, only gradients that push `inputs` higher than
+        the bound are passed through. No gradients are passed through to the bound.
+
+        Args:
+          inputs: input tensor
+          bound: lower bound for the input tensor
+          name: name for this op
+
+        Returns:
+          tf.maximum(inputs, bound)
+        """
+        with ops.name_scope(name, 'GDNLowerBound', [inputs, bound]) as scope:
+            inputs = ops.convert_to_tensor(inputs, name='inputs')
+            bound = ops.convert_to_tensor(bound, name='bound')
+            with ops.get_default_graph().gradient_override_map(
+                    {'Maximum': 'GDNLowerBound'}):
+                return math_ops.maximum(inputs, bound, name=scope)
+
+    @staticmethod
+    def _lower_bound_grad(op, grad):
+        """Gradient for `_lower_bound`.
+
+        Args:
+          op: the tensorflow op for which to calculate a gradient
+          grad: gradient with respect to the output of the op
+
+        Returns:
+          gradients with respect to the inputs of the op
+        """
+        inputs = op.inputs[0]
+        bound = op.inputs[1]
+        pass_through_if = math_ops.logical_or(inputs >= bound, grad < 0)
+        return [math_ops.cast(pass_through_if, grad.dtype) * grad, None]
+
+    def build(self, input_shape):
+        channel_axis = self._channel_axis()
+        input_shape = tensor_shape.TensorShape(input_shape)
+        num_channels = input_shape.dims[channel_axis].value
+        if num_channels is None:
+            raise ValueError('The channel dimension of the inputs to `GDN` '
+                             'must be defined.')
+        self._input_rank = input_shape.ndims
+        self.input_spec = input_spec.InputSpec(
+            ndim=input_shape.ndims, axes={channel_axis: num_channels})
+
+        pedestal = array_ops.constant(
+            self._reparam_offset**2, dtype=self.dtype)
+        beta_bound = array_ops.constant(
+            (self._beta_min + self._reparam_offset**2)**.5, dtype=self.dtype)
+        gamma_bound = array_ops.constant(
+            self._reparam_offset, dtype=self.dtype)
+
+        def beta_initializer(shape, dtype=None, partition_info=None):
+            del partition_info  # unused
+            pedestal = array_ops.constant(
+                self._reparam_offset**2, dtype=self.dtype)
+            return math_ops.sqrt(array_ops.ones(shape, dtype=dtype) + pedestal)
+
+        def gamma_initializer(shape, dtype=None, partition_info=None):
+            del partition_info  # unused
+            assert len(shape) == 2
+            assert shape[0] == shape[1]
+            eye = linalg_ops.eye(shape[0], dtype=dtype)
+            pedestal = array_ops.constant(
+                self._reparam_offset**2, dtype=self.dtype)
+            return math_ops.sqrt(self._gamma_init * eye + pedestal)
+
+        beta = self.add_variable(
+            'reparam_beta',
+            shape=[num_channels],
+            initializer=beta_initializer,
+            dtype=self.dtype,
+            trainable=True)
+        beta = self._lower_bound(beta, beta_bound)
+        self.beta = math_ops.square(beta) - pedestal
+
+        gamma = self.add_variable(
+            'reparam_gamma',
+            shape=[num_channels, num_channels],
+            initializer=gamma_initializer,
+            dtype=self.dtype,
+            trainable=True)
+        gamma = self._lower_bound(gamma, gamma_bound)
+        self.gamma = math_ops.square(gamma) - pedestal
+
+        self.built = True
+
+    def call(self, inputs):
+        inputs = ops.convert_to_tensor(inputs, dtype=self.dtype)
+        ndim = self._input_rank
+
+        shape = self.gamma.get_shape().as_list()
+        gamma = array_ops.reshape(self.gamma, (ndim - 2) * [1] + shape)
+
+        # Compute normalization pool.
+        if self.data_format == 'channels_first':
+            norm_pool = nn.convolution(
+                math_ops.square(inputs),
+                gamma,
+                'VALID',
+                data_format='NC' + 'DHW' [-(ndim - 2):])
+            if ndim == 3:
+                norm_pool = array_ops.expand_dims(norm_pool, 2)
+                norm_pool = nn.bias_add(
+                    norm_pool, self.beta, data_format='NCHW')
+                norm_pool = array_ops.squeeze(norm_pool, [2])
+            elif ndim == 5:
+                shape = array_ops.shape(norm_pool)
+                norm_pool = array_ops.reshape(norm_pool, shape[:3] + [-1])
+                norm_pool = nn.bias_add(
+                    norm_pool, self.beta, data_format='NCHW')
+                norm_pool = array_ops.reshape(norm_pool, shape)
+            else:  # ndim == 4
+                norm_pool = nn.bias_add(
+                    norm_pool, self.beta, data_format='NCHW')
+        else:  # channels_last
+            norm_pool = nn.convolution(math_ops.square(inputs), gamma, 'VALID')
+            norm_pool = nn.bias_add(norm_pool, self.beta, data_format='NHWC')
+        norm_pool = math_ops.sqrt(norm_pool)
+
+        if self.inverse:
+            outputs = inputs * norm_pool
+        else:
+            outputs = inputs / norm_pool
+        outputs.set_shape(inputs.get_shape())
+        return outputs
+
+    def compute_output_shape(self, input_shape):
+        channel_axis = self._channel_axis()
+        input_shape = tensor_shape.TensorShape(input_shape)
+        if not 3 <= input_shape.ndim <= 5:
+            raise ValueError(
+                '`input_shape` must be of rank 3 to 5, inclusive.')
+        if input_shape.dims[channel_axis].value is None:
+            raise ValueError(
+                'The channel dimension of `input_shape` must be defined.')
+        return input_shape
+
+
+ops.RegisterGradient('GDNLowerBound')(
+    GDN._lower_bound_grad)  # pylint:disable=protected-access
+
+
+def gdn(inputs,
+        inverse=False,
+        beta_min=1e-6,
+        gamma_init=.1,
+        reparam_offset=2**-18,
+        data_format='channels_last',
+        activity_regularizer=None,
+        trainable=True,
+        name=None,
+        reuse=None):
+    """Functional interface for GDN layer.
+
+    Based on the papers:
+
+      "Density Modeling of Images using a Generalized Normalization
+      Transformation"
+      Johannes Ballé, Valero Laparra, Eero P. Simoncelli
+      https://arxiv.org/abs/1511.06281
+
+      "End-to-end Optimized Image Compression"
+      Johannes Ballé, Valero Laparra, Eero P. Simoncelli
+      https://arxiv.org/abs/1611.01704
+
+    Implements an activation function that is essentially a multivariate
+    generalization of a particular sigmoid-type function:
+
+    ```
+    y[i] = x[i] / sqrt(beta[i] + sum_j(gamma[j, i] * x[j]))
+    ```
+
+    where `i` and `j` run over channels. This implementation never sums across
+    spatial dimensions. It is similar to local response normalization, but much
+    more flexible, as `beta` and `gamma` are trainable parameters.
+
+    Args:
+      inputs: Tensor input.
+      inverse: If `False` (default), compute GDN response. If `True`, compute IGDN
+        response (one step of fixed point iteration to invert GDN; the division is
+        replaced by multiplication).
+      beta_min: Lower bound for beta, to prevent numerical error from causing
+        square root of zero or negative values.
+      gamma_init: The gamma matrix will be initialized as the identity matrix
+        multiplied with this value. If set to zero, the layer is effectively
+        initialized to the identity operation, since beta is initialized as one. A
+        good default setting is somewhere between 0 and 0.5.
+      reparam_offset: Offset added to the reparameterization of beta and gamma.
+        The reparameterization of beta and gamma as their square roots lets the
+        training slow down when their values are close to zero, which is desirable
+        as small values in the denominator can lead to a situation where gradient
+        noise on beta/gamma leads to extreme amounts of noise in the GDN
+        activations. However, without the offset, we would get zero gradients if
+        any elements of beta or gamma were exactly zero, and thus the training
+        could get stuck. To prevent this, we add this small constant. The default
+        value was empirically determined as a good starting point. Making it
+        bigger potentially leads to more gradient noise on the activations, making
+        it too small may lead to numerical precision issues.
+      data_format: Format of input tensor. Currently supports `'channels_first'`
+        and `'channels_last'`.
+      activity_regularizer: Regularizer function for the output.
+      trainable: Boolean, if `True`, also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+      name: String, the name of the layer. Layers with the same name will share
+        weights, but to avoid mistakes we require `reuse=True` in such cases.
+      reuse: Boolean, whether to reuse the weights of a previous layer by the same
+        name.
+
+    Returns:
+      Output tensor.
+    """
+    layer = GDN(
+        inverse=inverse,
+        beta_min=beta_min,
+        gamma_init=gamma_init,
+        reparam_offset=reparam_offset,
+        data_format=data_format,
+        activity_regularizer=activity_regularizer,
+        trainable=trainable,
+        name=name,
+        dtype=inputs.dtype.base_dtype,
+        _scope=name,
+        _reuse=reuse)
+    return layer.apply(inputs)
+
+
+@add_arg_scope
+def layer_norm(inputs,
+               center=True,
+               scale=True,
+               activation_fn=None,
+               reuse=None,
+               variables_collections=None,
+               outputs_collections=None,
+               trainable=True,
+               begin_norm_axis=1,
+               begin_params_axis=-1,
+               scope=None):
+    """Adds a Layer Normalization layer.
+
+    Based on the paper:
+
+      "Layer Normalization"
+
+      Jimmy Lei Ba, Jamie Ryan Kiros, Geoffrey E. Hinton
+
+      https://arxiv.org/abs/1607.06450.
+
+    Can be used as a normalizer function for conv2d and fully_connected.
+
+    Given a tensor `inputs` of rank `R`, moments are calculated and normalization
+    is performed over axes `begin_norm_axis ... R - 1`.  Scaling and centering,
+    if requested, is performed over axes `begin_params_axis .. R - 1`.
+
+    By default, `begin_norm_axis = 1` and `begin_params_axis = -1`,
+    meaning that normalization is performed over all but the first axis
+    (the `HWC` if `inputs` is `NHWC`), while the `beta` and `gamma` trainable
+    parameters are calculated for the rightmost axis (the `C` if `inputs` is
+    `NHWC`).  Scaling and recentering is performed via broadcast of the
+    `beta` and `gamma` parameters with the normalized tensor.
+
+    The shapes of `beta` and `gamma` are `inputs.shape[begin_params_axis:]`,
+    and this part of the inputs' shape must be fully defined.
+
+    Args:
+      inputs: A tensor having rank `R`. The normalization is performed over axes
+        `begin_norm_axis ... R - 1` and centering and scaling parameters are
+        calculated over `begin_params_axis ... R - 1`.
+      center: If True, add offset of `beta` to normalized tensor. If False, `beta`
+        is ignored.
+      scale: If True, multiply by `gamma`. If False, `gamma` is not used. When the
+        next layer is linear (also e.g. `nn.relu`), this can be disabled since the
+        scaling can be done by the next layer.
+      activation_fn: Activation function, default set to None to skip it and
+        maintain a linear activation.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional collections for the variables.
+      outputs_collections: Collections to add the outputs.
+      trainable: If `True` also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+      begin_norm_axis: The first normalization dimension: normalization will be
+        performed along dimensions `begin_norm_axis : rank(inputs)`
+      begin_params_axis: The first parameter (beta, gamma) dimension: scale and
+        centering parameters will have dimensions
+        `begin_params_axis : rank(inputs)` and will be broadcast with the
+          normalized inputs accordingly.
+      scope: Optional scope for `variable_scope`.
+
+    Returns:
+      A `Tensor` representing the output of the operation, having the same
+      shape and dtype as `inputs`.
+
+    Raises:
+      ValueError: If the rank of `inputs` is not known at graph build time,
+        or if `inputs.shape[begin_params_axis:]` is not fully defined at
+        graph build time.
+    """
+    with variable_scope.variable_scope(
+            scope, 'LayerNorm', [inputs], reuse=reuse) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        inputs_shape = inputs.shape
+        inputs_rank = inputs_shape.ndims
+        if inputs_rank is None:
+            raise ValueError('Inputs %s has undefined rank.' % inputs.name)
+        dtype = inputs.dtype.base_dtype
+        if begin_norm_axis < 0:
+            begin_norm_axis = inputs_rank + begin_norm_axis
+        if begin_params_axis >= inputs_rank or begin_norm_axis >= inputs_rank:
+            raise ValueError('begin_params_axis (%d) and begin_norm_axis (%d) '
+                             'must be < rank(inputs) (%d)' %
+                             (begin_params_axis, begin_norm_axis, inputs_rank))
+        params_shape = inputs_shape[begin_params_axis:]
+        if not params_shape.is_fully_defined():
+            raise ValueError(
+                'Inputs %s: shape(inputs)[%s:] is not fully defined: %s' %
+                (inputs.name, begin_params_axis, inputs_shape))
+        # Allocate parameters for the beta and gamma of the normalization.
+        beta, gamma = None, None
+        if center:
+            beta_collections = utils.get_variable_collections(variables_collections,
+                                                              'beta')
+            beta = variables.model_variable(
+                'beta',
+                shape=params_shape,
+                dtype=dtype,
+                initializer=init_ops.zeros_initializer(),
+                collections=beta_collections,
+                trainable=trainable)
+        if scale:
+            gamma_collections = utils.get_variable_collections(
+                variables_collections, 'gamma')
+            gamma = variables.model_variable(
+                'gamma',
+                shape=params_shape,
+                dtype=dtype,
+                initializer=init_ops.ones_initializer(),
+                collections=gamma_collections,
+                trainable=trainable)
+        # By default, compute the moments across all the dimensions except the one with index 0.
+        norm_axes = list(range(begin_norm_axis, inputs_rank))
+        mean, variance = nn.moments(inputs, norm_axes, keep_dims=True)
+        # Compute layer normalization using the batch_normalization function.
+        # Note that epsilon must be increased for float16 due to the limited
+        # representable range.
+        variance_epsilon = 1e-12 if dtype != dtypes.float16 else 1e-3
+        outputs = nn.batch_normalization(
+            inputs,
+            mean,
+            variance,
+            offset=beta,
+            scale=gamma,
+            variance_epsilon=variance_epsilon)
+        outputs.set_shape(inputs_shape)
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def images_to_sequence(inputs,
+                       data_format=DATA_FORMAT_NHWC,
+                       outputs_collections=None,
+                       scope=None):
+    """Convert a batch of images into a batch of sequences.
+
+    Args:
+      inputs: a (num_images, height, width, depth) tensor
+      data_format: A string. `NHWC` (default) and `NCHW` are supported.
+      outputs_collections: The collections to which the outputs are added.
+      scope: Optional scope for name_scope.
+
+    Raises:
+       ValueError: If `data_format` is not either NCHW or NHWC.
+
+    Returns:
+      (width, num_images*height, depth) sequence tensor
+    """
+    if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+        raise ValueError('data_format has to be either NCHW or NHWC.')
+    with ops.name_scope(scope, 'ImagesToSequence', [inputs]) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        df = ('channels_first'
+              if data_format and data_format.startswith('NC') else 'channels_last')
+        if df == 'channels_first':
+            inputs = array_ops.transpose(inputs, [0, 2, 3, 1])
+        _, _, width, depth = inputs.get_shape().as_list()
+        s = array_ops.shape(inputs)
+        batch_size, height = s[0], s[1]
+        transposed = array_ops.transpose(inputs, [2, 0, 1, 3])
+        outputs = array_ops.reshape(
+            transposed, [width, batch_size * height, depth])
+        return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def max_pool2d(inputs,
+               kernel_size,
+               stride=2,
+               padding='VALID',
+               data_format=DATA_FORMAT_NHWC,
+               outputs_collections=None,
+               scope=None):
+    """Adds a 2D Max Pooling op.
+
+    It is assumed that the pooling is done per image but not in batch or channels.
+
+    Args:
+      inputs: A 4-D tensor of shape `[batch_size, height, width, channels]` if
+        `data_format` is `NHWC`, and `[batch_size, channels, height, width]` if
+        `data_format` is `NCHW`.
+      kernel_size: A list of length 2: [kernel_height, kernel_width] of the
+        pooling kernel over which the op is computed. Can be an int if both values
+        are the same.
+      stride: A list of length 2: [stride_height, stride_width]. Can be an int if
+        both strides are the same. Note that presently both strides must have the
+        same value.
+      padding: The padding method, either 'VALID' or 'SAME'.
+      data_format: A string. `NHWC` (default) and `NCHW` are supported.
+      outputs_collections: The collections to which the outputs are added.
+      scope: Optional scope for name_scope.
+
+    Returns:
+      A `Tensor` representing the results of the pooling operation.
+
+    Raises:
+      ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+      ValueError: If 'kernel_size' is not a 2-D list
+    """
+    if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+        raise ValueError('data_format has to be either NCHW or NHWC.')
+    with ops.name_scope(scope, 'MaxPool2D', [inputs]) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        df = ('channels_first'
+              if data_format and data_format.startswith('NC') else 'channels_last')
+        layer = pooling_layers.MaxPooling2D(
+            pool_size=kernel_size,
+            strides=stride,
+            padding=padding,
+            data_format=df,
+            _scope=sc)
+        outputs = layer.apply(inputs)
+        return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def max_pool3d(inputs,
+               kernel_size,
+               stride=2,
+               padding='VALID',
+               data_format=DATA_FORMAT_NDHWC,
+               outputs_collections=None,
+               scope=None):
+    """Adds a 3D Max Pooling op.
+
+    It is assumed that the pooling is done per image but not in batch or channels.
+
+    Args:
+      inputs: A 5-D tensor of shape `[batch_size, depth, height, width, channels]`
+        if `data_format` is `NDHWC`, and `[batch_size, channels, depth, height,
+        width]` if `data_format` is `NCDHW`.
+      kernel_size: A list of length 3: [kernel_depth, kernel_height, kernel_width]
+        of the pooling kernel over which the op is computed. Can be an int if both
+        values are the same.
+      stride: A list of length 3: [stride_depth, stride_height, stride_width]. Can
+        be an int if both strides are the same. Note that presently both strides
+        must have the same value.
+      padding: The padding method, either 'VALID' or 'SAME'.
+      data_format: A string. `NDHWC` (default) and `NCDHW` are supported.
+      outputs_collections: The collections to which the outputs are added.
+      scope: Optional scope for name_scope.
+
+    Returns:
+      A `Tensor` representing the results of the pooling operation.
+
+    Raises:
+      ValueError: If `data_format` is neither `NDHWC` nor `NCDHW`.
+      ValueError: If 'kernel_size' is not a 3-D list
+    """
+    if data_format not in (DATA_FORMAT_NCDHW, DATA_FORMAT_NDHWC):
+        raise ValueError('data_format has to be either NCDHW or NDHWC.')
+    with ops.name_scope(scope, 'MaxPool3D', [inputs]) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        df = ('channels_first'
+              if data_format and data_format.startswith('NC') else 'channels_last')
+        layer = pooling_layers.MaxPooling3D(
+            pool_size=kernel_size,
+            strides=stride,
+            padding=padding,
+            data_format=df,
+            _scope=sc)
+        outputs = layer.apply(inputs)
+        return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def pool(inputs,
+         kernel_size,
+         pooling_type,
+         padding='VALID',
+         data_format=None,
+         dilation_rate=1,
+         stride=1,
+         outputs_collections=None,
+         scope=None):
+    # pylint: disable=line-too-long
+    """Adds a pooling op.
+
+
+    Args:
+      inputs: Tensor of rank N+2, of shape `[batch_size] + input_spatial_shape +
+        [num_channels]` if data_format does not start with "NC" (default), or
+        `[batch_size, num_channels] + input_spatial_shape` if data_format starts
+        with "NC".  Pooling happens over the spatial dimensions only.
+      kernel_size: Sequence of N ints >= 1.  Can also be a single integer to
+        specify the same value for all spatial dimensions.
+      pooling_type: Specifies pooling operation, must be "AVG" or "MAX".
+      padding: The padding algorithm, must be "SAME" or "VALID".
+      data_format: A string or None.  Specifies whether the channel dimension of
+        the `input` and output is the last dimension (default, or if `data_format`
+        does not start with "NC"), or the second dimension (if `data_format`
+        starts with "NC").  For N=1, the valid values are "NWC" (default) and
+        "NCW".  For N=2, the valid values are "NHWC" (default) and "NCHW". For
+        N=3, the valid values are "NDHWC" (default) and "NCDHW".
+      dilation_rate: Optional.  Dilation rate.  Sequence of N ints >= 1.  Defaults
+        to [1]*N.  Can also be a single integer to specify the same value for all
+        spatial dimensions.  If any value of dilation_rate is > 1, then all values
+        of stride must be 1.
+      stride: Optional.  Sequence of N ints >= 1.  Defaults to [1]*N.  Can also be
+        a single integer to specify the same value for all spatial dimensions.  If
+        any value of stride is > 1, then all values of dilation_rate must be 1.
+      outputs_collections: The collections to which the outputs are added.
+      scope: Optional scope for name_scope.
+
+    Returns:
+      A `Tensor` representing the results of the pooling operation.
+
+    Raises:
+      ValueError: If arguments are invalid.
+
+    """
+    # pylint: enable=line-too-long
+    with ops.name_scope(scope, '%s_pool' % (pooling_type.lower()),
+                        [inputs]) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        input_rank = inputs.get_shape().ndims
+        if input_rank is None:
+            raise ValueError('Rank of inputs must be known')
+        if input_rank < 3:
+            raise ValueError('Rank of inputs must be >= 3')
+        num_spatial_dims = input_rank - 2
+        output = nn.pool(
+            input=inputs,
+            window_shape=utils.n_positive_integers(
+                num_spatial_dims, kernel_size),
+            pooling_type=pooling_type,
+            padding=padding,
+            data_format=data_format,
+            dilation_rate=utils.n_positive_integers(num_spatial_dims,
+                                                    dilation_rate),
+            strides=utils.n_positive_integers(num_spatial_dims, stride),
+            name=sc)
+        return utils.collect_named_outputs(outputs_collections, sc, output)
+
+
+@add_arg_scope
+def one_hot_encoding(labels,
+                     num_classes,
+                     on_value=1.0,
+                     off_value=0.0,
+                     outputs_collections=None,
+                     scope=None):
+    """Transform numeric labels into onehot_labels using `tf.one_hot`.
+
+    Args:
+      labels: [batch_size] target labels.
+      num_classes: Total number of classes.
+      on_value: A scalar defining the on-value.
+      off_value: A scalar defining the off-value.
+      outputs_collections: Collection to add the outputs.
+      scope: Optional scope for name_scope.
+
+    Returns:
+      One-hot encoding of the labels.
+    """
+    with ops.name_scope(scope, 'OneHotEncoding', [labels, num_classes]) as sc:
+        labels = ops.convert_to_tensor(labels)
+        if labels.dtype == dtypes.int32:
+            labels = standard_ops.to_int64(labels)
+        outputs = standard_ops.one_hot(
+            labels, num_classes, on_value=on_value, off_value=off_value)
+        return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+def _apply_activation(y, activation_fn, output_collections):
+    if activation_fn is not None:
+        y = activation_fn(y)
+    ops.add_to_collections(
+        list(output_collections or []) + [ops.GraphKeys.ACTIVATIONS], y)
+    return y
+
+
+def repeat(inputs, repetitions, layer, *args, **kwargs):
+    """Applies the same layer with the same arguments repeatedly.
+
+    ```python
+      y = repeat(x, 3, conv2d, 64, [3, 3], scope='conv1')
+      # It is equivalent to:
+
+      x = conv2d(x, 64, [3, 3], scope='conv1/conv1_1')
+      x = conv2d(x, 64, [3, 3], scope='conv1/conv1_2')
+      y = conv2d(x, 64, [3, 3], scope='conv1/conv1_3')
+    ```
+
+    If the `scope` argument is not given in `kwargs`, it is set to
+    `layer.__name__`, or `layer.func.__name__` (for `functools.partial`
+    objects). If neither `__name__` nor `func.__name__` is available, the
+    layers are called with `scope='stack'`.
+
+    Args:
+      inputs: A `Tensor` suitable for layer.
+      repetitions: Int, number of repetitions.
+      layer: A layer with arguments `(inputs, *args, **kwargs)`
+      *args: Extra args for the layer.
+      **kwargs: Extra kwargs for the layer.
+
+    Returns:
+      A tensor result of applying the layer, repetitions times.
+    Raises:
+      ValueError: If the op is unknown or wrong.
+    """
+    scope = kwargs.pop('scope', None)
+    with variable_scope.variable_scope(scope, 'Repeat', [inputs]):
+        inputs = ops.convert_to_tensor(inputs)
+        if scope is None:
+            if hasattr(layer, '__name__'):
+                scope = layer.__name__
+            elif hasattr(layer, 'func') and hasattr(layer.func, '__name__'):
+                # In case layer is a functools.partial.
+                scope = layer.func.__name__
+            else:
+                scope = 'repeat'
+        outputs = inputs
+        for i in range(repetitions):
+            kwargs['scope'] = scope + '_' + str(i + 1)
+            outputs = layer(outputs, *args, **kwargs)
+        return outputs
+
+
+@custom_gradient.custom_gradient
+def scale_gradient(inputs, gradient_multiplier):
+    """Identity operation, but with the gradient multiplied by a tensor.
+
+    The TensorFlow gradient system will compute the gradient with respect to
+    `inputs` as the product of the gradient with respect to the `output`
+    multiplied by a specified `gradient_multiplier` tensor.  If
+    `gradient_multiplier` is equal to 1, then this results in the true gradient.
+    Otherwise, it results in a scaled gradient.
+
+    This can be useful for adjusting the relative learning rate of different
+    parameter tensors when performing gradient descent, and because this rescaling
+    can be inserted at arbitrary locations within a graph, is often more
+    convenient to apply than simply rescaling the final computed gradients.
+
+    Args:
+      inputs: Tensor to be output.
+      gradient_multiplier: Tensor by which to multiply the gradient with respect
+        to `output` to compute the gradient with respect to `inputs`.  Its shape
+        must be broadcastable to the shape of `inputs`.
+
+    Returns:
+      output Tensor, equal to `inputs`.
+    """
+
+    def grad(dy):
+        return [dy * gradient_multiplier, None]
+
+    return inputs, grad
+
+
+@add_arg_scope
+def separable_convolution2d(
+        inputs,
+        num_outputs,
+        kernel_size,
+        depth_multiplier=1,
+        stride=1,
+        padding='SAME',
+        data_format=DATA_FORMAT_NHWC,
+        rate=1,
+        activation_fn=nn.relu,
+        normalizer_fn=None,
+        normalizer_params=None,
+        weights_initializer=initializers.xavier_initializer(),
+        pointwise_initializer=None,
+        weights_regularizer=None,
+        biases_initializer=init_ops.zeros_initializer(),
+        biases_regularizer=None,
+        reuse=None,
+        variables_collections=None,
+        outputs_collections=None,
+        trainable=True,
+        scope=None):
+    """Adds a depth-separable 2D convolution with optional batch_norm layer.
+
+    This op first performs a depthwise convolution that acts separately on
+    channels, creating a variable called `depthwise_weights`. If `num_outputs`
+    is not None, it adds a pointwise convolution that mixes channels, creating a
+    variable called `pointwise_weights`. Then, if `normalizer_fn` is None,
+    it adds bias to the result, creating a variable called 'biases', otherwise,
+    the `normalizer_fn` is applied. It finally applies an activation function
+    to produce the end result.
+
+    Args:
+      inputs: A tensor of size [batch_size, height, width, channels].
+      num_outputs: The number of pointwise convolution output filters. If is None,
+        then we skip the pointwise convolution stage.
+      kernel_size: A list of length 2: [kernel_height, kernel_width] of of the
+        filters. Can be an int if both values are the same.
+      depth_multiplier: The number of depthwise convolution output channels for
+        each input channel. The total number of depthwise convolution output
+        channels will be equal to `num_filters_in * depth_multiplier`.
+      stride: A list of length 2: [stride_height, stride_width], specifying the
+        depthwise convolution stride. Can be an int if both strides are the same.
+      padding: One of 'VALID' or 'SAME'.
+      data_format: A string. `NHWC` (default) and `NCHW` are supported.
+      rate: A list of length 2: [rate_height, rate_width], specifying the dilation
+        rates for atrous convolution. Can be an int if both rates are the same. If
+        any value is larger than one, then both stride values need to be one.
+      activation_fn: Activation function. The default value is a ReLU function.
+        Explicitly set it to None to skip it and maintain a linear activation.
+      normalizer_fn: Normalization function to use instead of `biases`. If
+        `normalizer_fn` is provided then `biases_initializer` and
+        `biases_regularizer` are ignored and `biases` are not created nor added.
+        default set to None for no normalizer function
+      normalizer_params: Normalization function parameters.
+      weights_initializer: An initializer for the depthwise weights.
+      pointwise_initializer: An initializer for the pointwise weights. default set
+        to None, means use weights_initializer.
+      weights_regularizer: Optional regularizer for the weights.
+      biases_initializer: An initializer for the biases. If None skip biases.
+      biases_regularizer: Optional regularizer for the biases.
+      reuse: Whether or not the layer and its variables should be reused. To be
+        able to reuse the layer scope must be given.
+      variables_collections: Optional list of collections for all the variables or
+        a dictionary containing a different list of collection per variable.
+      outputs_collections: Collection to add the outputs.
+      trainable: Whether or not the variables should be trainable or not.
+      scope: Optional scope for variable_scope.
+
+    Returns:
+      A `Tensor` representing the output of the operation.
+    Raises:
+      ValueError: If `data_format` is invalid.
+    """
+    if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+        raise ValueError('data_format has to be either NCHW or NHWC.')
+    layer_variable_getter = _build_variable_getter({
+        'bias': 'biases',
+        'depthwise_kernel': 'depthwise_weights',
+        'pointwise_kernel': 'pointwise_weights'
+    })
+
+    with variable_scope.variable_scope(
+        scope,
+        'SeparableConv2d', [inputs],
+        reuse=reuse,
+            custom_getter=layer_variable_getter) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+
+        if pointwise_initializer is None:
+            pointwise_initializer = weights_initializer
+
+        df = ('channels_first'
+              if data_format and data_format.startswith('NC') else 'channels_last')
+        if num_outputs is not None:
+            # Apply separable conv using the SeparableConvolution2D layer.
+            layer = convolutional_layers.SeparableConvolution2D(
+                filters=num_outputs,
+                kernel_size=kernel_size,
+                strides=stride,
+                padding=padding,
+                data_format=df,
+                dilation_rate=utils.two_element_tuple(rate),
+                activation=None,
+                depth_multiplier=depth_multiplier,
+                use_bias=not normalizer_fn and biases_initializer,
+                depthwise_initializer=weights_initializer,
+                pointwise_initializer=pointwise_initializer,
+                bias_initializer=biases_initializer,
+                depthwise_regularizer=weights_regularizer,
+                pointwise_regularizer=weights_regularizer,
+                bias_regularizer=biases_regularizer,
+                activity_regularizer=None,
+                trainable=trainable,
+                name=sc.name,
+                dtype=inputs.dtype.base_dtype,
+                _scope=sc,
+                _reuse=reuse)
+            outputs = layer.apply(inputs)
+
+            # Add variables to collections.
+            _add_variable_to_collections(layer.depthwise_kernel,
+                                         variables_collections, 'weights')
+            _add_variable_to_collections(layer.pointwise_kernel,
+                                         variables_collections, 'weights')
+            if layer.bias is not None:
+                _add_variable_to_collections(layer.bias, variables_collections,
+                                             'biases')
+
+            if normalizer_fn is not None:
+                normalizer_params = normalizer_params or {}
+                outputs = normalizer_fn(outputs, **normalizer_params)
+        else:
+            # Actually apply depthwise conv instead of separable conv.
+            dtype = inputs.dtype.base_dtype
+            kernel_h, kernel_w = utils.two_element_tuple(kernel_size)
+            stride_h, stride_w = utils.two_element_tuple(stride)
+            num_filters_in = utils.channel_dimension(
+                inputs.get_shape(), df, min_rank=4)
+            weights_collections = utils.get_variable_collections(
+                variables_collections, 'weights')
+
+            depthwise_shape = [kernel_h, kernel_w,
+                               num_filters_in, depth_multiplier]
+            depthwise_weights = variables.model_variable(
+                'depthwise_weights',
+                shape=depthwise_shape,
+                dtype=dtype,
+                initializer=weights_initializer,
+                regularizer=weights_regularizer,
+                trainable=trainable,
+                collections=weights_collections)
+            strides = [
+                1, 1, stride_h, stride_w
+            ] if data_format.startswith('NC') else [1, stride_h, stride_w, 1]
+
+            outputs = nn.depthwise_conv2d(
+                inputs,
+                depthwise_weights,
+                strides,
+                padding,
+                rate=utils.two_element_tuple(rate),
+                data_format=data_format)
+            num_outputs = depth_multiplier * num_filters_in
+
+            if normalizer_fn is not None:
+                normalizer_params = normalizer_params or {}
+                outputs = normalizer_fn(outputs, **normalizer_params)
+            else:
+                if biases_initializer is not None:
+                    biases_collections = utils.get_variable_collections(
+                        variables_collections, 'biases')
+                    biases = variables.model_variable(
+                        'biases',
+                        shape=[
+                            num_outputs,
+                        ],
+                        dtype=dtype,
+                        initializer=biases_initializer,
+                        regularizer=biases_regularizer,
+                        trainable=trainable,
+                        collections=biases_collections)
+                    outputs = nn.bias_add(
+                        outputs, biases, data_format=data_format)
+
+        if activation_fn is not None:
+            outputs = activation_fn(outputs)
+        return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def sequence_to_images(inputs,
+                       height,
+                       output_data_format='channels_last',
+                       outputs_collections=None,
+                       scope=None):
+    """Convert a batch of sequences into a batch of images.
+
+    Args:
+      inputs: (num_steps, num_batches, depth) sequence tensor
+      height: the height of the images
+      output_data_format: Format of output tensor. Currently supports
+        `'channels_first'` and `'channels_last'`.
+      outputs_collections: The collections to which the outputs are added.
+      scope: Optional scope for name_scope.
+
+    Returns:
+      A tensor representing the output of the operation.
+    """
+    with ops.name_scope(scope, 'SequenceToImages', [inputs]) as sc:
+        inputs = ops.convert_to_tensor(inputs)
+        width, num_batches, depth = inputs.get_shape().as_list()
+        if num_batches is None:
+            num_batches = -1
+        else:
+            num_batches //= height
+        reshaped = array_ops.reshape(
+            inputs, [width, num_batches, height, depth])
+        if output_data_format == 'channels_first':
+            outputs = array_ops.transpose(reshaped, [1, 3, 2, 0])
+        else:
+            outputs = array_ops.transpose(reshaped, [1, 2, 0, 3])
+        return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def softmax(logits, scope=None):
+    """Performs softmax on Nth dimension of N-dimensional logit tensor.
+
+    For two-dimensional logits this reduces to tf.nn.softmax. The N-th dimension
+    needs to have a specified number of elements (number of classes).
+
+    Args:
+      logits: N-dimensional `Tensor` with logits, where N > 1.
+      scope: Optional scope for variable_scope.
+
+    Returns:
+      A `Tensor` with same shape and type as logits.
+    """
+    with variable_scope.variable_scope(scope, 'softmax', [logits]):
+        num_logits = utils.last_dimension(logits.get_shape(), min_rank=2)
+        logits_2d = array_ops.reshape(logits, [-1, num_logits])
+        predictions = nn.softmax(logits_2d)
+        predictions = array_ops.reshape(predictions, array_ops.shape(logits))
+        if not tf.executing_eagerly():
+            predictions.set_shape(logits.get_shape())
+        return predictions
+
+
+@add_arg_scope
+def spatial_softmax(features,
+                    temperature=None,
+                    name=None,
+                    variables_collections=None,
+                    trainable=True,
+                    data_format='NHWC'):
+    """Computes the spatial softmax of a convolutional feature map.
+
+    First computes the softmax over the spatial extent of each channel of a
+    convolutional feature map. Then computes the expected 2D position of the
+    points of maximal activation for each channel, resulting in a set of
+    feature keypoints [i1, j1, ... iN, jN] for all N channels.
+
+    Read more here:
+    "Learning visual feature spaces for robotic manipulation with
+    deep spatial autoencoders." Finn et al., http://arxiv.org/abs/1509.06113.
+
+    Args:
+      features: A `Tensor` of size [batch_size, W, H, num_channels]; the
+        convolutional feature map.
+      temperature: Softmax temperature (optional). If None, a learnable
+        temperature is created.
+      name: A name for this operation (optional).
+      variables_collections: Collections for the temperature variable.
+      trainable: If `True` also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+      data_format: A string. `NHWC` (default) and `NCHW` are supported.
+
+    Returns:
+      feature_keypoints: A `Tensor` with size [batch_size, num_channels * 2];
+        the expected 2D locations of each channel's feature keypoint (normalized
+        to the range (-1,1)). The inner dimension is arranged as
+        [i1, j1, ... iN, jN].
+    Raises:
+      ValueError: If unexpected data_format specified.
+      ValueError: If num_channels dimension is unspecified.
+    """
+    with variable_scope.variable_scope(name, 'spatial_softmax'):
+        shape = array_ops.shape(features)
+        static_shape = features.shape
+        if data_format == DATA_FORMAT_NHWC:
+            height, width, num_channels = shape[1], shape[2], static_shape[3]
+        elif data_format == DATA_FORMAT_NCHW:
+            num_channels, height, width = static_shape[1], shape[2], shape[3]
+        else:
+            raise ValueError('data_format has to be either NCHW or NHWC.')
+        if tensor_shape.dimension_value(num_channels) is None:
+            raise ValueError('The num_channels dimension of the inputs to '
+                             '`spatial_softmax` should be defined. Found `None`.')
+
+        with ops.name_scope('spatial_softmax_op', 'spatial_softmax_op', [features]):
+            # Create tensors for x and y coordinate values, scaled to range [-1, 1].
+            pos_x, pos_y = array_ops.meshgrid(
+                math_ops.lin_space(-1., 1., num=height),
+                math_ops.lin_space(-1., 1., num=width),
+                indexing='ij')
+            pos_x = array_ops.reshape(pos_x, [height * width])
+            pos_y = array_ops.reshape(pos_y, [height * width])
+
+            if temperature is None:
+                temp_initializer = init_ops.ones_initializer()
+            else:
+                temp_initializer = init_ops.constant_initializer(temperature)
+
+            if not trainable:
+                temp_collections = None
+            else:
+                temp_collections = utils.get_variable_collections(
+                    variables_collections, 'temperature')
+
+            temperature = variables.model_variable(
+                'temperature',
+                shape=(),
+                dtype=dtypes.float32,
+                initializer=temp_initializer,
+                collections=temp_collections,
+                trainable=trainable)
+            if data_format == 'NCHW':
+                features = array_ops.reshape(features, [-1, height * width])
+            else:
+                features = array_ops.reshape(
+                    array_ops.transpose(features, [0, 3, 1, 2]), [-1, height * width])
+
+            softmax_attention = nn.softmax(features / temperature)
+            expected_x = math_ops.reduce_sum(
+                pos_x * softmax_attention, [1], keepdims=True)
+            expected_y = math_ops.reduce_sum(
+                pos_y * softmax_attention, [1], keepdims=True)
+            expected_xy = array_ops.concat([expected_x, expected_y], 1)
+            feature_keypoints = array_ops.reshape(
+                expected_xy, [-1, tensor_shape.dimension_value(num_channels) * 2])
+            feature_keypoints.set_shape(
+                [None, tensor_shape.dimension_value(num_channels) * 2])
+    return feature_keypoints
+
+
+def stack(inputs, layer, stack_args, **kwargs):
+    """Builds a stack of layers by applying layer repeatedly using stack_args.
+
+    `stack` allows you to repeatedly apply the same operation with different
+    arguments `stack_args[i]`. For each application of the layer, `stack` creates
+    a new scope appended with an increasing number. For example:
+
+    ```python
+      y = stack(x, fully_connected, [32, 64, 128], scope='fc')
+      # It is equivalent to:
+
+      x = fully_connected(x, 32, scope='fc/fc_1')
+      x = fully_connected(x, 64, scope='fc/fc_2')
+      y = fully_connected(x, 128, scope='fc/fc_3')
+    ```
+
+    If the `scope` argument is not given in `kwargs`, it is set to
+    `layer.__name__`, or `layer.func.__name__` (for `functools.partial`
+    objects). If neither `__name__` nor `func.__name__` is available, the
+    layers are called with `scope='stack'`.
+
+    Args:
+      inputs: A `Tensor` suitable for layer.
+      layer: A layer with arguments `(inputs, *args, **kwargs)`
+      stack_args: A list/tuple of parameters for each call of layer.
+      **kwargs: Extra kwargs for the layer.
+
+    Returns:
+      A `Tensor` result of applying the stacked layers.
+
+    Raises:
+      ValueError: If the op is unknown or wrong.
+    """
+    scope = kwargs.pop('scope', None)
+    if not isinstance(stack_args, (list, tuple)):
+        raise ValueError('stack_args need to be a list or tuple')
+    with variable_scope.variable_scope(scope, 'Stack', [inputs]):
+        inputs = ops.convert_to_tensor(inputs)
+        if scope is None:
+            if hasattr(layer, '__name__'):
+                scope = layer.__name__
+            elif hasattr(layer, 'func') and hasattr(layer.func, '__name__'):
+                # In case layer is a functools.partial.
+                scope = layer.func.__name__
+            else:
+                scope = 'stack'
+        outputs = inputs
+        for i in range(len(stack_args)):
+            kwargs['scope'] = scope + '_' + str(i + 1)
+            layer_args = stack_args[i]
+            if not isinstance(layer_args, (list, tuple)):
+                layer_args = [layer_args]
+            outputs = layer(outputs, *layer_args, **kwargs)
+        return outputs
+
+
+@add_arg_scope
+def unit_norm(inputs, dim, epsilon=1e-7, scope=None):
+    """Normalizes the given input across the specified dimension to unit length.
+
+    Note that the rank of `input` must be known.
+
+    Args:
+      inputs: A `Tensor` of arbitrary size.
+      dim: The dimension along which the input is normalized.
+      epsilon: A small value to add to the inputs to avoid dividing by zero.
+      scope: Optional scope for variable_scope.
+
+    Returns:
+      The normalized `Tensor`.
+
+    Raises:
+      ValueError: If dim is smaller than the number of dimensions in 'inputs'.
+    """
+    with variable_scope.variable_scope(scope, 'UnitNorm', [inputs]):
+        if not inputs.get_shape():
+            raise ValueError('The input rank must be known.')
+        input_rank = len(inputs.get_shape().as_list())
+        if dim < 0 or dim >= input_rank:
+            raise ValueError(
+                'dim must be positive but smaller than the input rank.')
+
+        lengths = math_ops.sqrt(
+            epsilon + math_ops.reduce_sum(math_ops.square(inputs), dim, True))
+        multiples = []
+        if dim > 0:
+            multiples.append(array_ops.ones([dim], dtypes.int32))
+        multiples.append(
+            array_ops.strided_slice(array_ops.shape(inputs), [dim], [dim + 1]))
+        if dim < (input_rank - 1):
+            multiples.append(array_ops.ones(
+                [input_rank - 1 - dim], dtypes.int32))
+        multiples = array_ops.concat(multiples, 0)
+        return math_ops.div(inputs, array_ops.tile(lengths, multiples))
+
+
+@add_arg_scope
+def maxout(inputs, num_units, axis=-1, scope=None):
+    """Adds a maxout op from https://arxiv.org/abs/1302.4389
+
+    "Maxout Networks" Ian J. Goodfellow, David Warde-Farley, Mehdi Mirza, Aaron
+    Courville,
+     Yoshua Bengio
+
+    Usually the operation is performed in the filter/channel dimension. This can
+    also be
+    used after fully-connected layers to reduce number of features.
+
+    Arguments:
+      inputs: Tensor input
+      num_units: Specifies how many features will remain after maxout in the
+        `axis` dimension (usually channel). This must be a factor of number of
+        features.
+      axis: The dimension where max pooling will be performed. Default is the last
+        dimension.
+      scope: Optional scope for variable_scope.
+
+    Returns:
+      A `Tensor` representing the results of the pooling operation.
+
+    Raises:
+      ValueError: if num_units is not multiple of number of features.
+    """
+    with variable_scope.variable_scope(scope, 'MaxOut', [inputs]):
+        inputs = ops.convert_to_tensor(inputs)
+        shape = inputs.get_shape().as_list()
+        num_channels = shape[axis]
+        if num_channels % num_units:
+            raise ValueError('number of features({}) is not '
+                             'a multiple of num_units({})'.format(
+                                 num_channels, num_units))
+        shape[axis] = num_units
+        shape += [num_channels // num_units]
+
+        # Dealing with batches with arbitrary sizes
+        for i in range(len(shape)):
+            if shape[i] is None:
+                shape[i] = array_ops.shape(inputs)[i]
+        outputs = math_ops.reduce_max(
+            array_ops.reshape(inputs, shape), -1, keepdims=False)
+        return outputs
+
+
+def poincare_normalize(x, axis=1, epsilon=1e-5, name=None):
+    """Project into the Poincare ball with norm <= 1.0 - epsilon.
+
+    https://en.wikipedia.org/wiki/Poincare_ball_model
+
+    Used in
+    Poincare Embeddings for Learning Hierarchical Representations
+    Maximilian Nickel, Douwe Kiela
+    https://arxiv.org/pdf/1705.08039.pdf
+
+    For a 1-D tensor with `axis = 0`, computes
+
+                  (x * (1 - epsilon)) / ||x||     if ||x|| > 1 - epsilon
+        output =
+                   x                              otherwise
+
+    For `x` with more dimensions, independently normalizes each 1-D slice along
+    dimension `axis`.
+
+    Args:
+      x: A `Tensor`.
+      axis: Axis along which to normalize.  A scalar or a vector of integers.
+      epsilon: A small deviation from the edge of the unit sphere for numerical
+        stability.
+      name: A name for this operation (optional).
+
+    Returns:
+      A `Tensor` with the same shape as `x`.
+    """
+    with ops.name_scope(name, 'poincare_normalize', [x]) as name:
+        x = ops.convert_to_tensor(x, name='x')
+        square_sum = math_ops.reduce_sum(
+            math_ops.square(x), axis, keepdims=True)
+        x_inv_norm = math_ops.rsqrt(square_sum)
+        x_inv_norm = math_ops.minimum((1. - epsilon) * x_inv_norm, 1.)
+        return math_ops.multiply(x, x_inv_norm, name=name)
+
+
+def legacy_fully_connected(x,
+                           num_output_units,
+                           activation_fn=None,
+                           weight_init=initializers.xavier_initializer(),
+                           bias_init=init_ops.zeros_initializer(),
+                           name=None,
+                           weight_collections=(ops.GraphKeys.WEIGHTS,),
+                           bias_collections=(ops.GraphKeys.BIASES,),
+                           output_collections=(ops.GraphKeys.ACTIVATIONS,),
+                           trainable=True,
+                           weight_regularizer=None,
+                           bias_regularizer=None):
+    # pylint: disable=anomalous-backslash-in-string
+    r"""Adds the parameters for a fully connected layer and returns the output.
+
+    A fully connected layer is generally defined as a matrix multiply:
+    `y = f(w * x + b)` where `f` is given by `activation_fn`. If
+    `activation_fn` is `None`, the result of `y = w * x + b` is
+    returned.
+
+    If `x` has shape [\\(\text{dim}_0, \text{dim}_1, ..., \text{dim}_n\\)]
+    with more than 2 dimensions (\\(n > 1\\)), then we repeat the matrix
+    multiply along the first dimensions. The result r is a tensor of shape
+    [\\(\text{dim}_0, ..., \text{dim}_{n-1},\\) `num_output_units`],
+    where \\( r_{i_0, ..., i_{n-1}, k} =
+    \sum_{0 \leq j < \text{dim}_n} x_{i_0, ... i_{n-1}, j} \cdot w_{j, k}\\).
+    This is accomplished by reshaping `x` to 2-D
+    [\\(\text{dim}_0 \cdot ... \cdot \text{dim}_{n-1}, \text{dim}_n\\)]
+    before the matrix multiply and afterwards reshaping it to
+    [\\(\text{dim}_0, ..., \text{dim}_{n-1},\\) `num_output_units`].
+
+    This op creates `w` and optionally `b`. Bias (`b`) can be disabled by setting
+    `bias_init` to `None`.
+
+    The variable creation is compatible with `tf.compat.v1.variable_scope` and so
+    can be
+    reused with `tf.compat.v1.variable_scope` or `tf.compat.v1.make_template`.
+
+    Most of the details of variable creation can be controlled by specifying the
+    initializers (`weight_init` and `bias_init`) and in which collections to place
+    the created variables (`weight_collections` and `bias_collections`; note that
+    the variables are always added to the `VARIABLES` collection). The output of
+    the layer can be placed in custom collections using `output_collections`.
+    The collections arguments default to `WEIGHTS`, `BIASES` and `ACTIVATIONS`,
+    respectively.
+
+    A per layer regularization can be specified by setting `weight_regularizer`
+    and `bias_regularizer`, which are applied to the weights and biases
+    respectively, and whose output is added to the `REGULARIZATION_LOSSES`
+    collection.
+
+    Args:
+      x: The input `Tensor`.
+      num_output_units: The size of the output.
+      activation_fn: Activation function, default set to None to skip it and
+        maintain a linear activation.
+      weight_init: An optional weight initialization, defaults to
+        `xavier_initializer`.
+      bias_init: An initializer for the bias, defaults to 0. Set to `None` in
+        order to disable bias.
+      name: The name for this operation is used to name operations and to find
+        variables. If specified it must be unique for this scope, otherwise a
+        unique name starting with "fully_connected" will be created.  See
+        `tf.compat.v1.variable_scope` for details.
+      weight_collections: List of graph collections to which weights are added.
+      bias_collections: List of graph collections to which biases are added.
+      output_collections: List of graph collections to which outputs are added.
+      trainable: If `True` also add variables to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+      weight_regularizer: A regularizer like the result of `l1_regularizer` or
+        `l2_regularizer`. Used for weights.
+      bias_regularizer: A regularizer like the result of `l1_regularizer` or
+        `l2_regularizer`. Used for biases.
+
+    Returns:
+      The output of the fully connected layer.
+
+    Raises:
+      ValueError: If x has rank less than 2 or if its last dimension is not set.
+    """
+    with variable_scope.variable_scope(name, 'fully_connected', [x]):
+        x = ops.convert_to_tensor(x)
+        dims = x.get_shape().dims
+        if dims is None:
+            raise ValueError('dims of x must be known but is None')
+        if len(dims) < 2:
+            raise ValueError(
+                'rank of x must be at least 2 not: %d' % len(dims))
+        num_input_units = dims[-1].value
+        if num_input_units is None:
+            raise ValueError('last dimension of x must be known but is None')
+        dtype = x.dtype.base_dtype
+
+        weight_collections = set(
+            list(weight_collections or []) + [ops.GraphKeys.GLOBAL_VARIABLES])
+        w = variable_scope.get_variable(
+            'weights',
+            shape=[num_input_units, num_output_units],
+            dtype=dtype,
+            initializer=weight_init,
+            collections=weight_collections,
+            regularizer=weight_regularizer,
+            trainable=trainable)
+        x_2_dim = x if len(dims) <= 2 else array_ops.reshape(
+            x, [-1, num_input_units])
+        y = standard_ops.matmul(x_2_dim, w)
+
+        if bias_init is not None:
+            bias_collections = set(
+                list(bias_collections or []) + [ops.GraphKeys.GLOBAL_VARIABLES])
+            b = variable_scope.get_variable(
+                'bias',
+                shape=[num_output_units],
+                dtype=dtype,
+                initializer=bias_init,
+                collections=bias_collections,
+                regularizer=bias_regularizer,
+                trainable=trainable)
+
+            y = nn.bias_add(y, b)
+
+        if len(dims) > 2:
+            out_shape = array_ops.unstack(array_ops.shape(x))
+            out_shape[-1] = num_output_units
+
+            y = array_ops.reshape(y, array_ops.stack(out_shape))
+
+            static_shape = x.get_shape().as_list()
+            static_shape[-1] = num_output_units
+            y.set_shape(static_shape)
+
+        return _apply_activation(y, activation_fn, output_collections)
+
+
+# Simple aliases which remove the activation_fn parameter.
+elu = functools.partial(fully_connected, activation_fn=nn.elu)
+legacy_relu = functools.partial(legacy_fully_connected, activation_fn=nn.relu)
+legacy_linear = functools.partial(legacy_fully_connected, activation_fn=None)
+relu = functools.partial(fully_connected, activation_fn=nn.relu)
+relu6 = functools.partial(fully_connected, activation_fn=nn.relu6)
+linear = functools.partial(fully_connected, activation_fn=None)
+
+# Simple alias.
+conv1d = convolution1d
+conv2d = convolution2d
+conv3d = convolution3d
+conv2d_transpose = convolution2d_transpose
+conv3d_transpose = convolution3d_transpose
+conv2d_in_plane = convolution2d_in_plane
+separable_conv2d = separable_convolution2d

--- a/astronet/astro_fc_model/utils.py
+++ b/astronet/astro_fc_model/utils.py
@@ -1,0 +1,372 @@
+# coding=utf-8
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Common util functions used by layers.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from collections import namedtuple
+from collections import OrderedDict
+
+# pylint: disable=g-direct-tensorflow-import
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.framework import tensor_util
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import variables
+
+__all__ = ['collect_named_outputs',
+           'constant_value',
+           'static_cond',
+           'smart_cond',
+           'get_variable_collections',
+           'two_element_tuple',
+           'n_positive_integers',
+           'channel_dimension',
+           'last_dimension']
+
+NamedOutputs = namedtuple('NamedOutputs', ['name', 'outputs'])
+
+
+def collect_named_outputs(collections, alias, outputs):
+  """Add `Tensor` outputs tagged with alias to collections.
+
+  It is useful to collect end-points or tags for summaries. Example of usage:
+
+  logits = collect_named_outputs('end_points', 'inception_v3/logits', logits)
+  assert 'inception_v3/logits' in logits.aliases
+
+  Args:
+    collections: A collection or list of collections. If None skip collection.
+    alias: String to append to the list of aliases of outputs, for example,
+           'inception_v3/conv1'.
+    outputs: Tensor, an output tensor to collect
+
+  Returns:
+    The outputs Tensor to allow inline call.
+  """
+  if collections:
+    append_tensor_alias(outputs, alias)
+    ops.add_to_collections(collections, outputs)
+  return outputs
+
+
+def append_tensor_alias(tensor, alias):
+  """Append an alias to the list of aliases of the tensor.
+
+  Args:
+    tensor: A `Tensor`.
+    alias: String, to add to the list of aliases of the tensor.
+
+  Returns:
+    The tensor with a new alias appended to its list of aliases.
+  """
+  # Remove ending '/' if present.
+  if alias[-1] == '/':
+    alias = alias[:-1]
+  if hasattr(tensor, 'aliases'):
+    tensor.aliases.append(alias)
+  else:
+    tensor.aliases = [alias]
+  return tensor
+
+
+def gather_tensors_aliases(tensors):
+  """Given a list of tensors, gather their aliases.
+
+  Args:
+    tensors: A list of `Tensors`.
+
+  Returns:
+    A list of strings with the aliases of all tensors.
+  """
+  aliases = []
+  for tensor in tensors:
+    aliases += get_tensor_aliases(tensor)
+  return aliases
+
+
+def get_tensor_aliases(tensor):
+  """Get a list with the aliases of the input tensor.
+
+  If the tensor does not have any alias, it would default to its its op.name or
+  its name.
+
+  Args:
+    tensor: A `Tensor`.
+
+  Returns:
+    A list of strings with the aliases of the tensor.
+  """
+  if hasattr(tensor, 'aliases'):
+    aliases = tensor.aliases
+  else:
+    if tensor.name[-2:] == ':0':
+      # Use op.name for tensor ending in :0
+      aliases = [tensor.op.name]
+    else:
+      aliases = [tensor.name]
+  return aliases
+
+
+def convert_collection_to_dict(collection, clear_collection=False):
+  """Returns an OrderedDict of Tensors with their aliases as keys.
+
+  Args:
+    collection: A collection.
+    clear_collection: When True, it clears the collection after converting to
+      OrderedDict.
+
+  Returns:
+    An OrderedDict of {alias: tensor}
+  """
+  output = OrderedDict((alias, tensor)
+                       for tensor in ops.get_collection(collection)
+                       for alias in get_tensor_aliases(tensor))
+  if clear_collection:
+    ops.get_default_graph().clear_collection(collection)
+  return output
+
+
+def constant_value(value_or_tensor_or_var, dtype=None):
+  """Returns value if value_or_tensor_or_var has a constant value.
+
+  Args:
+    value_or_tensor_or_var: A value, a `Tensor` or a `Variable`.
+    dtype: Optional `tf.dtype`, if set it would check it has the right
+      dtype.
+
+  Returns:
+    The constant value or None if it not constant.
+
+  Raises:
+    ValueError: if value_or_tensor_or_var is None or the tensor_variable has the
+    wrong dtype.
+  """
+  if value_or_tensor_or_var is None:
+    raise ValueError('value_or_tensor_or_var cannot be None')
+  value = value_or_tensor_or_var
+  if isinstance(value_or_tensor_or_var, (ops.Tensor, variables.Variable)):
+    if dtype and value_or_tensor_or_var.dtype != dtype:
+      raise ValueError('It has the wrong type %s instead of %s' % (
+          value_or_tensor_or_var.dtype, dtype))
+    if isinstance(value_or_tensor_or_var, variables.Variable):
+      value = None
+    else:
+      value = tensor_util.constant_value(value_or_tensor_or_var)
+  return value
+
+
+def static_cond(pred, fn1, fn2):
+  """Return either fn1() or fn2() based on the boolean value of `pred`.
+
+  Same signature as `tf.cond()` but requires pred to be a bool.
+
+  Args:
+    pred: A value determining whether to return the result of `fn1` or `fn2`.
+    fn1: The callable to be performed if pred is true.
+    fn2: The callable to be performed if pred is false.
+
+  Returns:
+    Tensors returned by the call to either `fn1` or `fn2`.
+
+  Raises:
+    TypeError: if `fn1` or `fn2` is not callable.
+  """
+  if not callable(fn1):
+    raise TypeError('fn1 must be callable.')
+  if not callable(fn2):
+    raise TypeError('fn2 must be callable.')
+  if pred:
+    return fn1()
+  else:
+    return fn2()
+
+
+def smart_cond(pred, fn1, fn2, name=None):
+  """Return either fn1() or fn2() based on the boolean predicate/value `pred`.
+
+  If `pred` is bool or has a constant value it would use `static_cond`,
+  otherwise it would use `tf.cond`.
+
+  Args:
+    pred: A scalar determining whether to return the result of `fn1` or `fn2`.
+    fn1: The callable to be performed if pred is true.
+    fn2: The callable to be performed if pred is false.
+    name: Optional name prefix when using tf.cond
+  Returns:
+    Tensors returned by the call to either `fn1` or `fn2`.
+  """
+  pred_value = constant_value(pred)
+  if pred_value is not None:
+    # Use static_cond if pred has a constant value.
+    return static_cond(pred_value, fn1, fn2)
+  else:
+    # Use dynamic cond otherwise.
+    return control_flow_ops.cond(pred, fn1, fn2, name)
+
+
+def get_variable_collections(variables_collections, name):
+  if isinstance(variables_collections, dict):
+    variable_collections = variables_collections.get(name, None)
+  else:
+    variable_collections = variables_collections
+  return variable_collections
+
+
+def _get_dimension(shape, dim, min_rank=1):
+  """Returns the `dim` dimension of `shape`, while checking it has `min_rank`.
+
+  Args:
+    shape: A `TensorShape`.
+    dim: Integer, which dimension to return.
+    min_rank: Integer, minimum rank of shape.
+
+  Returns:
+    The value of the `dim` dimension.
+
+  Raises:
+    ValueError: if inputs don't have at least min_rank dimensions, or if the
+      first dimension value is not defined.
+  """
+  dims = shape.dims
+  if dims is None:
+    raise ValueError('dims of shape must be known but is None')
+  if len(dims) < min_rank:
+    raise ValueError('rank of shape must be at least %d not: %d' % (min_rank,
+                                                                    len(dims)))
+  value = dims[dim].value
+  if value is None:
+    raise ValueError(
+        'dimension %d of shape must be known but is None: %s' % (dim, shape))
+  return value
+
+
+def channel_dimension(shape, data_format, min_rank=1):
+  """Returns the channel dimension of shape, while checking it has min_rank.
+
+  Args:
+    shape: A `TensorShape`.
+    data_format: `channels_first` or `channels_last`.
+    min_rank: Integer, minimum rank of shape.
+
+  Returns:
+    The value of the first dimension.
+
+  Raises:
+    ValueError: if inputs don't have at least min_rank dimensions, or if the
+      first dimension value is not defined.
+  """
+  return _get_dimension(shape, 1 if data_format == 'channels_first' else -1,
+                        min_rank=min_rank)
+
+
+def last_dimension(shape, min_rank=1):
+  """Returns the last dimension of shape while checking it has min_rank.
+
+  Args:
+    shape: A `TensorShape`.
+    min_rank: Integer, minimum rank of shape.
+
+  Returns:
+    The value of the last dimension.
+
+  Raises:
+    ValueError: if inputs don't have at least min_rank dimensions, or if the
+      last dimension value is not defined.
+  """
+  return _get_dimension(shape, -1, min_rank=min_rank)
+
+
+def two_element_tuple(int_or_tuple):
+  """Converts `int_or_tuple` to height, width.
+
+  Several of the functions that follow accept arguments as either
+  a tuple of 2 integers or a single integer.  A single integer
+  indicates that the 2 values of the tuple are the same.
+
+  This functions normalizes the input value by always returning a tuple.
+
+  Args:
+    int_or_tuple: A list of 2 ints, a single int or a `TensorShape`.
+
+  Returns:
+    A tuple with 2 values.
+
+  Raises:
+    ValueError: If `int_or_tuple` it not well formed.
+  """
+  if isinstance(int_or_tuple, (list, tuple)):
+    if len(int_or_tuple) != 2:
+      raise ValueError('Must be a list with 2 elements: %s' % int_or_tuple)
+    return int(int_or_tuple[0]), int(int_or_tuple[1])
+  if isinstance(int_or_tuple, int):
+    return int(int_or_tuple), int(int_or_tuple)
+  if isinstance(int_or_tuple, tensor_shape.TensorShape):
+    if len(int_or_tuple) == 2:
+      return int_or_tuple[0], int_or_tuple[1]
+  raise ValueError('Must be an int, a list with 2 elements or a TensorShape of '
+                   'length 2')
+
+
+def n_positive_integers(n, value):
+  """Converts `value` to a sequence of `n` positive integers.
+
+  `value` may be either be a sequence of values convertible to `int`, or a
+  single value convertible to `int`, in which case the resulting integer is
+  duplicated `n` times.  It may also be a TensorShape of rank `n`.
+
+  Args:
+    n: Length of sequence to return.
+    value: Either a single value convertible to a positive `int` or an
+      `n`-element sequence of values convertible to a positive `int`.
+
+  Returns:
+    A tuple of `n` positive integers.
+
+  Raises:
+    TypeError: If `n` is not convertible to an integer.
+    ValueError: If `n` or `value` are invalid.
+  """
+
+  n_orig = n
+  n = int(n)
+  if n < 1 or n != n_orig:
+    raise ValueError('n must be a positive integer')
+
+  try:
+    value = int(value)
+  except (TypeError, ValueError):
+    sequence_len = len(value)
+    if sequence_len != n:
+      raise ValueError(
+          'Expected sequence of %d positive integers, but received %r' %
+          (n, value))
+    try:
+      values = tuple(int(x) for x in value)
+    except:
+      raise ValueError(
+          'Expected sequence of %d positive integers, but received %r' %
+          (n, value))
+    for x in values:
+      if x < 1:
+        raise ValueError('expected positive integer, but received %d' % x)
+    return values
+
+  if value < 1:
+    raise ValueError('expected positive integer, but received %d' % value)
+  return (value,) * n

--- a/astronet/ops/arg_scope.py
+++ b/astronet/ops/arg_scope.py
@@ -1,0 +1,213 @@
+# coding=utf-8
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains the arg_scope used for scoping layers arguments.
+
+  Allows one to define models much more compactly by eliminating boilerplate
+  code. This is accomplished through the use of argument scoping (arg_scope).
+
+  Example of how to use tf_slim.arg_scope:
+
+  ```
+  from astronet.tf_slim import layers
+
+  arg_scope = tf_slim.arg_scope
+
+  with arg_scope([layers.conv2d], padding='SAME',
+                 initializer=layers.variance_scaling_initializer(),
+                 regularizer=layers.l2_regularizer(0.05)):
+    net = layers.conv2d(inputs, 64, [11, 11], 4, padding='VALID', scope='conv1')
+    net = layers.conv2d(net, 256, [5, 5], scope='conv2')
+  ```
+  The first call to conv2d will behave as follows:
+    layers.conv2d(inputs, 64, [11, 11], 4, padding='VALID',
+                  initializer=layers.variance_scaling_initializer(),
+                  regularizer=layers.l2_regularizer(0.05), scope='conv1')
+
+  The second call to conv2d will also use the arg_scope's default for padding:
+    layers.conv2d(inputs, 256, [5, 5], padding='SAME',
+                  initializer=layers.variance_scaling_initializer(),
+                  regularizer=layers.l2_regularizer(0.05), scope='conv2')
+
+  Example of how to reuse an arg_scope:
+
+  ```
+  with arg_scope([layers.conv2d], padding='SAME',
+                 initializer=layers.variance_scaling_initializer(),
+                 regularizer=layers.l2_regularizer(0.05)) as sc:
+    net = layers.conv2d(net, 256, [5, 5], scope='conv1')
+    ....
+
+  with arg_scope(sc):
+    net = layers.conv2d(net, 256, [5, 5], scope='conv2')
+  ```
+
+  Example of how to use tf_slim.add_arg_scope to enable your
+  function to be called within an arg_scope later:
+
+  @tf_slim.add_arg_scope
+  def conv2d(*args, **kwargs)
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# pylint: disable=g-direct-tensorflow-import
+from tensorflow.python.util import tf_contextlib
+from tensorflow.python.util import tf_decorator
+
+__all__ = [
+    'arg_scope', 'add_arg_scope', 'current_arg_scope', 'has_arg_scope',
+    'arg_scoped_arguments', 'arg_scope_func_key'
+]
+
+_ARGSTACK = [{}]
+
+_DECORATED_OPS = {}
+
+
+def _get_arg_stack():
+    if _ARGSTACK:
+        return _ARGSTACK
+    else:
+        _ARGSTACK.append({})
+        return _ARGSTACK
+
+
+def current_arg_scope():
+    stack = _get_arg_stack()
+    return stack[-1]
+
+
+def arg_scope_func_key(op):
+    return getattr(op, '_key_op', str(op))
+
+
+def _name_op(op):
+    return (op.__module__, op.__name__)
+
+
+def _kwarg_names(func):
+    kwargs_length = len(func.__defaults__) if func.__defaults__ else 0
+    return func.__code__.co_varnames[-kwargs_length:func.__code__.co_argcount]
+
+
+def _add_op(op):
+    key_op = arg_scope_func_key(op)
+    _DECORATED_OPS[key_op] = _kwarg_names(op)
+
+
+@tf_contextlib.contextmanager
+def arg_scope(list_ops_or_scope, **kwargs):
+    """Stores the default arguments for the given set of list_ops.
+
+    For usage, please see examples at top of the file.
+
+    Args:
+      list_ops_or_scope: List or tuple of operations to set argument scope for or
+        a dictionary containing the current scope. When list_ops_or_scope is a
+        dict, kwargs must be empty. When list_ops_or_scope is a list or tuple,
+        then every op in it need to be decorated with @add_arg_scope to work.
+      **kwargs: keyword=value that will define the defaults for each op in
+                list_ops. All the ops need to accept the given set of arguments.
+
+    Yields:
+      the current_scope, which is a dictionary of {op: {arg: value}}
+    Raises:
+      TypeError: if list_ops is not a list or a tuple.
+      ValueError: if any op in list_ops has not be decorated with @add_arg_scope.
+    """
+    if isinstance(list_ops_or_scope, dict):
+        # Assumes that list_ops_or_scope is a scope that is being reused.
+        if kwargs:
+            raise ValueError('When attempting to re-use a scope by suppling a'
+                             'dictionary, kwargs must be empty.')
+        current_scope = list_ops_or_scope.copy()
+        try:
+            _get_arg_stack().append(current_scope)
+            yield current_scope
+        finally:
+            _get_arg_stack().pop()
+    else:
+        # Assumes that list_ops_or_scope is a list/tuple of ops with kwargs.
+        if not isinstance(list_ops_or_scope, (list, tuple)):
+            raise TypeError('list_ops_or_scope must either be a list/tuple or reused '
+                            'scope (i.e. dict)')
+        try:
+            current_scope = current_arg_scope().copy()
+            for op in list_ops_or_scope:
+                key = arg_scope_func_key(op)
+                if not has_arg_scope(op):
+                    raise ValueError('%s is not decorated with @add_arg_scope',
+                                     _name_op(op))
+                if key in current_scope:
+                    current_kwargs = current_scope[key].copy()
+                    current_kwargs.update(kwargs)
+                    current_scope[key] = current_kwargs
+                else:
+                    current_scope[key] = kwargs.copy()
+            _get_arg_stack().append(current_scope)
+            yield current_scope
+        finally:
+            _get_arg_stack().pop()
+
+
+def add_arg_scope(func):
+    """Decorates a function with args so it can be used within an arg_scope.
+
+    Args:
+      func: function to decorate.
+
+    Returns:
+      A tuple with the decorated function func_with_args().
+    """
+
+    def func_with_args(*args, **kwargs):
+        current_scope = current_arg_scope()
+        current_args = kwargs
+        key_func = arg_scope_func_key(func)
+        if key_func in current_scope:
+            current_args = current_scope[key_func].copy()
+            current_args.update(kwargs)
+        return func(*args, **current_args)
+
+    _add_op(func)
+    setattr(func_with_args, '_key_op', arg_scope_func_key(func))
+    return tf_decorator.make_decorator(func, func_with_args)
+
+
+def has_arg_scope(func):
+    """Checks whether a func has been decorated with @add_arg_scope or not.
+
+    Args:
+      func: function to check.
+
+    Returns:
+      a boolean.
+    """
+    return arg_scope_func_key(func) in _DECORATED_OPS
+
+
+def arg_scoped_arguments(func):
+    """Returns the list kwargs that arg_scope can set for a func.
+
+    Args:
+      func: function which has been decorated with @add_arg_scope.
+
+    Returns:
+      a list of kwargs names.
+    """
+    assert has_arg_scope(func)
+    return _DECORATED_OPS[arg_scope_func_key(func)]

--- a/astronet/ops/dataset_ops.py
+++ b/astronet/ops/dataset_ops.py
@@ -21,112 +21,115 @@ from __future__ import print_function
 import collections
 import six
 import tensorflow as tf
+from tensorflow.python.ops import lookup_ops
 
 
 def pad_tensor_to_batch_size(tensor, batch_size):
-  """Pads a Tensor along the batch dimension to the desired batch size."""
-  if batch_size < 2:
-    raise ValueError("Cannot pad along batch dimension with batch_size < 2.")
+    """Pads a Tensor along the batch dimension to the desired batch size."""
+    if batch_size < 2:
+        raise ValueError(
+            "Cannot pad along batch dimension with batch_size < 2.")
 
-  ndims = len(tensor.shape)
-  if ndims < 1:
-    raise ValueError("Cannot pad a 0-dimensional Tensor")
+    ndims = len(tensor.shape)
+    if ndims < 1:
+        raise ValueError("Cannot pad a 0-dimensional Tensor")
 
-  num_pad_examples = batch_size - tf.shape(input=tensor)[0]
+    num_pad_examples = batch_size - tf.shape(input=tensor)[0]
 
-  # paddings is a 2D Tensor with shape [ndims, 2]. Every element is zero except
-  # for paddings[0][1], which is the number of values to add along the 0-th
-  # dimension (the batch dimension) after the contents of the input tensor.
-  paddings = tf.compat.v1.sparse_to_dense(
-      sparse_indices=[[0, 1]],
-      output_shape=[ndims, 2],
-      sparse_values=num_pad_examples)
+    # paddings is a 2D Tensor with shape [ndims, 2]. Every element is zero except
+    # for paddings[0][1], which is the number of values to add along the 0-th
+    # dimension (the batch dimension) after the contents of the input tensor.
+    paddings = tf.compat.v1.sparse_to_dense(
+        sparse_indices=[[0, 1]],
+        output_shape=[ndims, 2],
+        sparse_values=num_pad_examples)
 
-  padded_tensor = tf.pad(tensor=tensor, paddings=paddings, name=tensor.op.name + "/pad")
+    padded_tensor = tf.pad(tensor=tensor, paddings=paddings,
+                           name=tensor.op.name + "/pad")
 
-  # Set the new shape.
-  output_shape = tensor.shape.as_list()
-  output_shape[0] = batch_size
-  padded_tensor.set_shape(output_shape)
+    # Set the new shape.
+    output_shape = tensor.shape.as_list()
+    output_shape[0] = batch_size
+    padded_tensor.set_shape(output_shape)
 
-  return padded_tensor
+    return padded_tensor
 
 
 def _recursive_pad_to_batch_size(tensor_or_collection, batch_size):
-  """Recursively pads to the batch size in a Tensor or collection of Tensors."""
-  if isinstance(tensor_or_collection, tf.Tensor):
-    return pad_tensor_to_batch_size(tensor_or_collection, batch_size)
+    """Recursively pads to the batch size in a Tensor or collection of Tensors."""
+    if isinstance(tensor_or_collection, tf.Tensor):
+        return pad_tensor_to_batch_size(tensor_or_collection, batch_size)
 
-  if isinstance(tensor_or_collection, dict):
-    return {
-        name: _recursive_pad_to_batch_size(t, batch_size)
-        for name, t in tensor_or_collection.items()
-    }
+    if isinstance(tensor_or_collection, dict):
+        return {
+            name: _recursive_pad_to_batch_size(t, batch_size)
+            for name, t in tensor_or_collection.items()
+        }
 
-  if isinstance(tensor_or_collection, collections.Iterable):
-    return [
-        _recursive_pad_to_batch_size(t, batch_size)
-        for t in tensor_or_collection
-    ]
+    if isinstance(tensor_or_collection, collections.Iterable):
+        return [
+            _recursive_pad_to_batch_size(t, batch_size)
+            for t in tensor_or_collection
+        ]
 
-  raise ValueError("Unknown input type: %s" % tensor_or_collection)
+    raise ValueError("Unknown input type: %s" % tensor_or_collection)
 
 
 def pad_dataset_to_batch_size(dataset, batch_size):
-  """Pads Tensors in a dataset along the batch dimension to batch_size.
+    """Pads Tensors in a dataset along the batch dimension to batch_size.
 
-  The output contains a 'weights' Tensor, which is a 0/1 indicator of padded
-  elements. If a 'weights' Tensor already exists in the input dataset, then that
-  Tensor is padded with zeros. If a 'weights' Tensor does not already exist,
-  then the input dataset is assumed to have a 'labels' Tensor which is used to
-  construct the weights.
+    The output contains a 'weights' Tensor, which is a 0/1 indicator of padded
+    elements. If a 'weights' Tensor already exists in the input dataset, then that
+    Tensor is padded with zeros. If a 'weights' Tensor does not already exist,
+    then the input dataset is assumed to have a 'labels' Tensor which is used to
+    construct the weights.
 
-  Args:
-    dataset: A tf.data.Dataset.
-    batch_size: Integer batch size.
+    Args:
+      dataset: A tf.data.Dataset.
+      batch_size: Integer batch size.
 
-  Returns:
-    A tf.data.Dataset.
-  """
+    Returns:
+      A tf.data.Dataset.
+    """
 
-  def map_fn(tensors):
-    """Pads Tensors along the batch dimension to the desired batch size."""
-    if not isinstance(tensors, dict):
-      raise ValueError(
-          "pad_dataset_to_batch_size requires a dictionary of named Tensors.")
+    def map_fn(tensors):
+        """Pads Tensors along the batch dimension to the desired batch size."""
+        if not isinstance(tensors, dict):
+            raise ValueError(
+                "pad_dataset_to_batch_size requires a dictionary of named Tensors.")
 
-    outputs = _recursive_pad_to_batch_size(tensors, batch_size)
-    if "weights" not in outputs:
-      weights = tf.ones_like(tensors["labels"], dtype=tf.float32)
-      outputs["weights"] = pad_tensor_to_batch_size(weights, batch_size)
+        outputs = _recursive_pad_to_batch_size(tensors, batch_size)
+        if "weights" not in outputs:
+            weights = tf.ones_like(tensors["labels"], dtype=tf.float32)
+            outputs["weights"] = pad_tensor_to_batch_size(weights, batch_size)
 
-    return outputs
+        return outputs
 
-  return dataset.map(map_fn)
+    return dataset.map(map_fn)
 
 
 def _recursive_set_batch_size(tensor_or_collection, batch_size):
-  """Recursively sets the batch size in a Tensor or collection of Tensors."""
-  if isinstance(tensor_or_collection, tf.Tensor):
-    t = tensor_or_collection
-    shape = t.shape.as_list()
-    shape[0] = batch_size
-    t.set_shape(t.shape.merge_with(shape))
-  elif isinstance(tensor_or_collection, dict):
-    for t in six.itervalues(tensor_or_collection):
-      _recursive_set_batch_size(t, batch_size)
-  elif isinstance(tensor_or_collection, collections.Iterable):
-    for t in tensor_or_collection:
-      _recursive_set_batch_size(t, batch_size)
-  else:
-    raise ValueError("Unknown input type: %s" % tensor_or_collection)
+    """Recursively sets the batch size in a Tensor or collection of Tensors."""
+    if isinstance(tensor_or_collection, tf.Tensor):
+        t = tensor_or_collection
+        shape = t.shape.as_list()
+        shape[0] = batch_size
+        t.set_shape(t.shape.merge_with(shape))
+    elif isinstance(tensor_or_collection, dict):
+        for t in six.itervalues(tensor_or_collection):
+            _recursive_set_batch_size(t, batch_size)
+    elif isinstance(tensor_or_collection, collections.Iterable):
+        for t in tensor_or_collection:
+            _recursive_set_batch_size(t, batch_size)
+    else:
+        raise ValueError("Unknown input type: %s" % tensor_or_collection)
 
-  return tensor_or_collection
+    return tensor_or_collection
 
 
 def set_batch_size(dataset, batch_size):
-  """Sets the batch dimension in all Tensors to batch_size."""
-  return dataset.map(lambda t: _recursive_set_batch_size(t, batch_size))
+    """Sets the batch dimension in all Tensors to batch_size."""
+    return dataset.map(lambda t: _recursive_set_batch_size(t, batch_size))
 
 
 def build_dataset(file_pattern,
@@ -138,149 +141,149 @@ def build_dataset(file_pattern,
                   shuffle_values_buffer=0,
                   repeat=1,
                   use_tpu=False):
-  """Builds an input pipeline that reads a dataset from sharded TFRecord files.
+    """Builds an input pipeline that reads a dataset from sharded TFRecord files.
 
-  Args:
-    file_pattern: File pattern matching input TFRecord files, e.g.
-        "/tmp/train-?????-of-00100". May also be a comma-separated list of file
-        patterns.
-    input_config: ConfigDict containing feature and label specifications.
-    batch_size: The number of examples per batch.
-    include_labels: Whether to read labels from the input files.
-    reverse_time_series_prob: If > 0, the time series features will be randomly
-        reversed with this probability. Within a given example, either all time
-        series features will be reversed, or none will be reversed.
-    shuffle_filenames: Whether to shuffle the order of TFRecord files between
-        epochs.
-    shuffle_values_buffer: If > 0, shuffle examples using a buffer of this size.
-    repeat: The number of times to repeat the dataset. If None or -1 the dataset
-        will repeat indefinitely.
-    use_tpu: Whether to build the dataset for TPU.
+    Args:
+      file_pattern: File pattern matching input TFRecord files, e.g.
+          "/tmp/train-?????-of-00100". May also be a comma-separated list of file
+          patterns.
+      input_config: ConfigDict containing feature and label specifications.
+      batch_size: The number of examples per batch.
+      include_labels: Whether to read labels from the input files.
+      reverse_time_series_prob: If > 0, the time series features will be randomly
+          reversed with this probability. Within a given example, either all time
+          series features will be reversed, or none will be reversed.
+      shuffle_filenames: Whether to shuffle the order of TFRecord files between
+          epochs.
+      shuffle_values_buffer: If > 0, shuffle examples using a buffer of this size.
+      repeat: The number of times to repeat the dataset. If None or -1 the dataset
+          will repeat indefinitely.
+      use_tpu: Whether to build the dataset for TPU.
 
-  Raises:
-    ValueError: If an input file pattern does not match any files, or if the
-        label IDs in input_config.label_map are not contiguous integers starting
-        at 0.
+    Raises:
+      ValueError: If an input file pattern does not match any files, or if the
+          label IDs in input_config.label_map are not contiguous integers starting
+          at 0.
 
-  Returns:
-    A tf.data.Dataset object.
-  """
-  file_patterns = file_pattern.split(",")
-  filenames = []
-  for p in file_patterns:
-    matches = tf.io.gfile.glob(p)
-    if not matches:
-      raise ValueError("Found no input files matching %s" % p)
-    filenames.extend(matches)
-  tf.compat.v1.logging.info("Building input pipeline from %d files matching patterns: %s",
-                  len(filenames), file_patterns)
+    Returns:
+      A tf.data.Dataset object.
+    """
+    file_patterns = file_pattern.split(",")
+    filenames = []
+    for p in file_patterns:
+        matches = tf.io.gfile.glob(p)
+        if not matches:
+            raise ValueError("Found no input files matching %s" % p)
+        filenames.extend(matches)
+    tf.compat.v1.logging.info("Building input pipeline from %d files matching patterns: %s",
+                              len(filenames), file_patterns)
 
-  if include_labels:
-    # Ensure that the label ids are contiguous integers starting at 0.
-    label_ids = set(input_config.label_map.values())
-    if label_ids != set(range(len(label_ids))):
-      raise ValueError(
-          "Label IDs must be contiguous integers starting at 0. Got: %s" %
-          label_ids)
-
-    # Create a HashTable mapping label strings to integer ids.
-    table_initializer = tf.contrib.lookup.KeyValueTensorInitializer(
-        keys=list(input_config.label_map.keys()),
-        values=list(input_config.label_map.values()),
-        key_dtype=tf.string,
-        value_dtype=tf.int32)
-    label_to_id = tf.contrib.lookup.HashTable(
-        table_initializer, default_value=-1)
-
-  def _example_parser(serialized_example):
-    """Parses a single tf.Example into feature and label tensors."""
-    # Set specifications for parsing the features.
-    data_fields = {
-        feature_name: tf.io.FixedLenFeature([feature.length], tf.float32)
-        for feature_name, feature in input_config.features.items()
-    }
     if include_labels:
-      data_fields[input_config.label_feature] = tf.io.FixedLenFeature([],
-                                                                   tf.string)
+        # Ensure that the label ids are contiguous integers starting at 0.
+        label_ids = set(input_config.label_map.values())
+        if label_ids != set(range(len(label_ids))):
+            raise ValueError(
+                "Label IDs must be contiguous integers starting at 0. Got: %s" %
+                label_ids)
 
-    # Parse the features.
-    parsed_features = tf.io.parse_single_example(
-        serialized=serialized_example, features=data_fields)
+        # Create a HashTable mapping label strings to integer ids.
+        table_initializer = lookup_ops.KeyValueTensorInitializer(
+            keys=list(input_config.label_map.keys()),
+            values=list(input_config.label_map.values()),
+            key_dtype=tf.string,
+            value_dtype=tf.int32)
+        label_to_id = lookup_ops.HashTable(
+            table_initializer, default_value=-1)
 
-    if reverse_time_series_prob > 0:
-      # Randomly reverse time series features with probability
-      # reverse_time_series_prob.
-      should_reverse = tf.less(
-          tf.random.uniform([], 0, 1),
-          reverse_time_series_prob,
-          name="should_reverse")
+    def _example_parser(serialized_example):
+        """Parses a single tf.Example into feature and label tensors."""
+        # Set specifications for parsing the features.
+        data_fields = {
+            feature_name: tf.io.FixedLenFeature([feature.length], tf.float32)
+            for feature_name, feature in input_config.features.items()
+        }
+        if include_labels:
+            data_fields[input_config.label_feature] = tf.io.FixedLenFeature([],
+                                                                            tf.string)
 
-    # Reorganize outputs.
-    output = {}
-    for feature_name, value in parsed_features.items():
-      if include_labels and feature_name == input_config.label_feature:
-        label_id = label_to_id.lookup(value)
-        # Ensure that the label_id is nonnegative to verify a successful hash
-        # map lookup.
-        assert_known_label = tf.Assert(
-            tf.greater_equal(label_id, tf.cast(0, dtype=tf.int32)),
-            ["Unknown label string:", value])
-        with tf.control_dependencies([assert_known_label]):
-          label_id = tf.identity(label_id)
+        # Parse the features.
+        parsed_features = tf.io.parse_single_example(
+            serialized=serialized_example, features=data_fields)
 
-        # We use the plural name "labels" in the output due to batching.
-        output["labels"] = label_id
-      elif input_config.features[feature_name].is_time_series:
-        # Possibly reverse.
         if reverse_time_series_prob > 0:
-          # pylint:disable=cell-var-from-loop
-          value = tf.cond(pred=should_reverse, true_fn=lambda: tf.reverse(value, axis=[0]),
-                          false_fn=lambda: tf.identity(value))
-          # pylint:enable=cell-var-from-loop
-        if "time_series_features" not in output:
-          output["time_series_features"] = {}
-        output["time_series_features"][feature_name] = value
-      else:
-        if "aux_features" not in output:
-          output["aux_features"] = {}
-        output["aux_features"][feature_name] = value
+            # Randomly reverse time series features with probability
+            # reverse_time_series_prob.
+            should_reverse = tf.less(
+                tf.random.uniform([], 0, 1),
+                reverse_time_series_prob,
+                name="should_reverse")
 
-    return output
+        # Reorganize outputs.
+        output = {}
+        for feature_name, value in parsed_features.items():
+            if include_labels and feature_name == input_config.label_feature:
+                label_id = label_to_id.lookup(value)
+                # Ensure that the label_id is nonnegative to verify a successful hash
+                # map lookup.
+                assert_known_label = tf.Assert(
+                    tf.greater_equal(label_id, tf.cast(0, dtype=tf.int32)),
+                    ["Unknown label string:", value])
+                with tf.control_dependencies([assert_known_label]):
+                    label_id = tf.identity(label_id)
 
-  # Create a string dataset of filenames, and possibly shuffle.
-  filename_dataset = tf.data.Dataset.from_tensor_slices(filenames)
-  if len(filenames) > 1 and shuffle_filenames:
-    filename_dataset = filename_dataset.shuffle(len(filenames))
+                # We use the plural name "labels" in the output due to batching.
+                output["labels"] = label_id
+            elif input_config.features[feature_name].is_time_series:
+                # Possibly reverse.
+                if reverse_time_series_prob > 0:
+                    # pylint:disable=cell-var-from-loop
+                    value = tf.cond(pred=should_reverse, true_fn=lambda: tf.reverse(value, axis=[0]),
+                                    false_fn=lambda: tf.identity(value))
+                    # pylint:enable=cell-var-from-loop
+                if "time_series_features" not in output:
+                    output["time_series_features"] = {}
+                output["time_series_features"][feature_name] = value
+            else:
+                if "aux_features" not in output:
+                    output["aux_features"] = {}
+                output["aux_features"][feature_name] = value
 
-  # Read serialized Example protos.
-  dataset = filename_dataset.flat_map(tf.data.TFRecordDataset)
+        return output
 
-  # Possibly shuffle. Note that we shuffle before repeat(), so we only shuffle
-  # elements among each "epoch" of data, and not across epochs of data.
-  if shuffle_values_buffer > 0:
-    dataset = dataset.shuffle(shuffle_values_buffer)
+    # Create a string dataset of filenames, and possibly shuffle.
+    filename_dataset = tf.data.Dataset.from_tensor_slices(filenames)
+    if len(filenames) > 1 and shuffle_filenames:
+        filename_dataset = filename_dataset.shuffle(len(filenames))
 
-  # Repeat.
-  if repeat != 1:
-    dataset = dataset.repeat(repeat)
+    # Read serialized Example protos.
+    dataset = filename_dataset.flat_map(tf.data.TFRecordDataset)
 
-  # Map the parser over the dataset.
-  dataset = dataset.map(_example_parser, num_parallel_calls=4)
+    # Possibly shuffle. Note that we shuffle before repeat(), so we only shuffle
+    # elements among each "epoch" of data, and not across epochs of data.
+    if shuffle_values_buffer > 0:
+        dataset = dataset.shuffle(shuffle_values_buffer)
 
-  # Batch results by up to batch_size.
-  dataset = dataset.batch(batch_size)
-  if repeat == -1 or repeat is None:
-    # The dataset repeats infinitely before batching, so each batch has the
-    # maximum number of elements.
-    dataset = set_batch_size(dataset, batch_size)
-  elif use_tpu:
-    # TPU requires all dimensions to be fixed. Since the dataset does not repeat
-    # infinitely before batching, the final batch may have fewer than batch_size
-    # elements. Therefore we pad to ensure that the final batch has batch_size
-    # elements.
-    dataset = pad_dataset_to_batch_size(dataset, batch_size)
+    # Repeat.
+    if repeat != 1:
+        dataset = dataset.repeat(repeat)
 
-  # Prefetch a few batches.
-  dataset = dataset.prefetch(max(1, int(256 / batch_size)))
+    # Map the parser over the dataset.
+    dataset = dataset.map(_example_parser, num_parallel_calls=4)
 
-  return dataset
+    # Batch results by up to batch_size.
+    dataset = dataset.batch(batch_size)
+    if repeat == -1 or repeat is None:
+        # The dataset repeats infinitely before batching, so each batch has the
+        # maximum number of elements.
+        dataset = set_batch_size(dataset, batch_size)
+    elif use_tpu:
+        # TPU requires all dimensions to be fixed. Since the dataset does not repeat
+        # infinitely before batching, the final batch may have fewer than batch_size
+        # elements. Therefore we pad to ensure that the final batch has batch_size
+        # elements.
+        dataset = pad_dataset_to_batch_size(dataset, batch_size)
+
+    # Prefetch a few batches.
+    dataset = dataset.prefetch(max(1, int(256 / batch_size)))
+
+    return dataset

--- a/astronet/ops/lookup_ops.py
+++ b/astronet/ops/lookup_ops.py
@@ -1,0 +1,673 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Lookup table operations."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.ops import gen_lookup_ops
+from tensorflow.python.ops import lookup_ops
+# pylint: disable=unused-import
+from tensorflow.python.ops.lookup_ops import FastHashSpec
+from tensorflow.python.ops.lookup_ops import HasherSpec
+from tensorflow.python.ops.lookup_ops import HashTable
+from tensorflow.python.ops.lookup_ops import IdTableWithHashBuckets
+from tensorflow.python.ops.lookup_ops import index_table_from_file
+from tensorflow.python.ops.lookup_ops import index_to_string_table_from_file
+from tensorflow.python.ops.lookup_ops import InitializableLookupTableBase
+from tensorflow.python.ops.lookup_ops import KeyValueTensorInitializer
+from tensorflow.python.ops.lookup_ops import LookupInterface
+from tensorflow.python.ops.lookup_ops import StrongHashSpec
+from tensorflow.python.ops.lookup_ops import TableInitializerBase
+from tensorflow.python.ops.lookup_ops import TextFileIdTableInitializer
+from tensorflow.python.ops.lookup_ops import TextFileIndex
+from tensorflow.python.ops.lookup_ops import TextFileInitializer
+from tensorflow.python.ops.lookup_ops import TextFileStringTableInitializer
+# pylint: enable=unused-import
+from tensorflow.python.training.saver import BaseSaverBuilder
+from tensorflow.python.util.deprecation import deprecated
+
+
+@deprecated("2017-04-10", "Use `index_table_from_file`.")
+def string_to_index_table_from_file(vocabulary_file=None,
+                                    num_oov_buckets=0,
+                                    vocab_size=None,
+                                    default_value=-1,
+                                    hasher_spec=FastHashSpec,
+                                    name=None):
+  return index_table_from_file(
+      vocabulary_file, num_oov_buckets, vocab_size, default_value, hasher_spec,
+      key_dtype=dtypes.string, name=name)
+
+
+@deprecated("2017-04-10", "Use `index_table_from_tensor`.")
+def string_to_index_table_from_tensor(mapping,
+                                      num_oov_buckets=0,
+                                      default_value=-1,
+                                      hasher_spec=FastHashSpec,
+                                      name=None):
+  with ops.name_scope(name, "string_to_index") as scope:
+    mapping = ops.convert_to_tensor(mapping)
+  if dtypes.string != mapping.dtype.base_dtype:
+    raise ValueError("string_to_index_table_from_tensor requires string.")
+  return index_table_from_tensor(
+      mapping, num_oov_buckets, default_value, hasher_spec, name=scope)
+
+
+def index_table_from_tensor(mapping,
+                            num_oov_buckets=0,
+                            default_value=-1,
+                            hasher_spec=FastHashSpec,
+                            dtype=dtypes.string,
+                            name=None):
+  """Returns a lookup table that converts a string tensor into int64 IDs.
+
+  This operation constructs a lookup table to convert tensor of strings into
+  int64 IDs. The mapping can be initialized from a string `mapping` 1-D tensor
+  where each element is a key and corresponding index within the tensor is the
+  value.
+
+  Any lookup of an out-of-vocabulary token will return a bucket ID based on its
+  hash if `num_oov_buckets` is greater than zero. Otherwise it is assigned the
+  `default_value`.
+  The bucket ID range is `[mapping size, mapping size + num_oov_buckets - 1]`.
+
+  The underlying table must be initialized by calling
+  `tf.tables_initializer.run()` or `table.init.run()` once.
+
+  Elements in `mapping` cannot have duplicates, otherwise when executing the
+  table initializer op, it will throw a `FailedPreconditionError`.
+
+  Sample Usages:
+
+  ```python
+  mapping_strings = tf.constant(["emerson", "lake", "palmer"])
+  table = tf.contrib.lookup.index_table_from_tensor(
+      mapping=mapping_strings, num_oov_buckets=1, default_value=-1)
+  features = tf.constant(["emerson", "lake", "and", "palmer"])
+  ids = table.lookup(features)
+  ...
+  tf.tables_initializer().run()
+
+  ids.eval()  ==> [0, 1, 3, 2]
+  ```
+
+  Args:
+    mapping: A 1-D `Tensor` that specifies the mapping of keys to indices. The
+      type of this object must be castable to `dtype`.
+    num_oov_buckets: The number of out-of-vocabulary buckets.
+    default_value: The value to use for out-of-vocabulary feature values.
+      Defaults to -1.
+    hasher_spec: A `HasherSpec` to specify the hash function to use for
+      assignment of out-of-vocabulary buckets.
+    dtype: The type of values passed to `lookup`. Only string and integers are
+      supported.
+    name: A name for this op (optional).
+
+  Returns:
+    The lookup table to map an input `Tensor` to index `int64` `Tensor`.
+
+  Raises:
+    ValueError: If `mapping` is invalid.
+    ValueError: If `num_oov_buckets` is negative.
+  """
+  if mapping is None:
+    raise ValueError("mapping must be specified.")
+  return lookup_ops.index_table_from_tensor(
+      vocabulary_list=mapping,
+      num_oov_buckets=num_oov_buckets,
+      default_value=default_value,
+      hasher_spec=hasher_spec,
+      dtype=dtype,
+      name=name)
+
+
+@deprecated(
+    "2017-01-07", "This op will be removed after the deprecation date. "
+    "Please switch to index_table_from_tensor and call the lookup "
+    "method of the returned table.")
+def string_to_index(tensor, mapping, default_value=-1, name=None):
+  """Maps `tensor` of strings into `int64` indices based on `mapping`.
+
+  This operation converts `tensor` of strings into `int64` indices.
+  The mapping is initialized from a string `mapping` tensor where each element
+  is a key and corresponding index within the tensor is the value.
+
+  Any entry in the input which does not have a corresponding entry in 'mapping'
+  (an out-of-vocabulary entry) is assigned the `default_value`
+
+  Elements in `mapping` cannot be duplicated, otherwise the initialization
+  will throw a FailedPreconditionError.
+
+  The underlying table must be initialized by calling
+  `tf.tables_initializer.run()` once.
+
+  For example:
+
+  ```python
+  mapping_strings = tf.constant(["emerson", "lake", "palmer"])
+  feats = tf.constant(["emerson", "lake", "and", "palmer"])
+  ids = tf.contrib.lookup.string_to_index(
+      feats, mapping=mapping_strings, default_value=-1)
+  ...
+  tf.tables_initializer().run()
+
+  ids.eval()  ==> [0, 1, -1, 2]
+  ```
+
+  Args:
+    tensor: A 1-D input `Tensor` with the strings to map to indices.
+    mapping: A 1-D string `Tensor` that specifies the mapping of strings to
+      indices.
+    default_value: The `int64` value to use for out-of-vocabulary strings.
+      Defaults to -1.
+    name: A name for this op (optional).
+
+  Returns:
+    The mapped indices. It has the same shape and tensor type (dense or sparse)
+    as `tensor`.
+  """
+  table = index_table_from_tensor(
+      mapping=mapping, default_value=default_value, name=name)
+  return table.lookup(tensor)
+
+
+def index_to_string_table_from_tensor(mapping, default_value="UNK", name=None):
+  """Returns a lookup table that maps a `Tensor` of indices into strings.
+
+  This operation constructs a lookup table to map int64 indices into string
+  values. The mapping is initialized from a string `mapping` 1-D `Tensor` where
+  each element is a value and the corresponding index within the tensor is the
+  key.
+
+  Any input which does not have a corresponding index in 'mapping'
+  (an out-of-vocabulary entry) is assigned the `default_value`
+
+  The underlying table must be initialized by calling
+  `tf.tables_initializer.run()` or `table.init.run()` once.
+
+  Elements in `mapping` cannot have duplicates, otherwise when executing the
+  table initializer op, it will throw a `FailedPreconditionError`.
+
+  Sample Usages:
+
+  ```python
+  mapping_string = tf.constant(["emerson", "lake", "palmer"])
+  indices = tf.constant([1, 5], tf.int64)
+  table = tf.contrib.lookup.index_to_string_table_from_tensor(
+      mapping_string, default_value="UNKNOWN")
+  values = table.lookup(indices)
+  ...
+  tf.tables_initializer().run()
+
+  values.eval() ==> ["lake", "UNKNOWN"]
+  ```
+
+  Args:
+    mapping: A 1-D string `Tensor` that specifies the strings to map from
+      indices.
+    default_value: The value to use for out-of-vocabulary indices.
+    name: A name for this op (optional).
+
+  Returns:
+    The lookup table to map a string values associated to a given index `int64`
+    `Tensors`.
+
+  Raises:
+    ValueError: when `mapping` is not set.
+  """
+
+  if mapping is None:
+    raise ValueError("mapping must be specified.")
+
+  return lookup_ops.index_to_string_table_from_tensor(
+      vocabulary_list=mapping, default_value=default_value, name=name)
+
+
+@deprecated(
+    "2017-01-07", "This op will be removed after the deprecation date. "
+    "Please switch to index_to_string_table_from_tensor and call the lookup "
+    "method of the returned table.")
+def index_to_string(tensor, mapping, default_value="UNK", name=None):
+  """Maps `tensor` of indices into string values based on `mapping`.
+
+  This operation converts `int64` indices into string values. The mapping is
+  initialized from a string `mapping` tensor where each element is a value and
+  the corresponding index within the tensor is the key.
+
+  Any input which does not have a corresponding index in 'mapping'
+  (an out-of-vocabulary entry) is assigned the `default_value`
+
+  The underlying table must be initialized by calling
+  `tf.tables_initializer.run()` once.
+
+  For example:
+
+  ```python
+  mapping_string = tf.constant(["emerson", "lake", "palmer"])
+  indices = tf.constant([1, 5], tf.int64)
+  values = tf.contrib.lookup.index_to_string(
+      indices, mapping=mapping_string, default_value="UNKNOWN")
+  ...
+  tf.tables_initializer().run()
+
+  values.eval() ==> ["lake", "UNKNOWN"]
+  ```
+
+  Args:
+    tensor: A `int64` `Tensor` with the indices to map to strings.
+    mapping: A 1-D string `Tensor` that specifies the strings to map from
+      indices.
+    default_value: The string value to use for out-of-vocabulary indices.
+    name: A name for this op (optional).
+
+  Returns:
+    The strings values associated to the indices. The resultant dense
+    feature value tensor has the same shape as the corresponding `indices`.
+  """
+  table = index_to_string_table_from_tensor(
+      mapping=mapping, default_value=default_value, name=name)
+  return table.lookup(tensor)
+
+
+class MutableHashTable(LookupInterface):
+  """A generic mutable hash table implementation.
+
+  Data can be inserted by calling the insert method. It does not support
+  initialization via the init method.
+
+  Example usage:
+
+  ```python
+  table = tf.contrib.lookup.MutableHashTable(key_dtype=tf.string,
+                                             value_dtype=tf.int64,
+                                             default_value=-1)
+  sess.run(table.insert(keys, values))
+  out = table.lookup(query_keys)
+  print(out.eval())
+  ```
+  """
+
+  def __init__(self,
+               key_dtype,
+               value_dtype,
+               default_value,
+               shared_name=None,
+               name="MutableHashTable",
+               checkpoint=True):
+    """Creates an empty `MutableHashTable` object.
+
+    Creates a table, the type of its keys and values are specified by key_dtype
+    and value_dtype, respectively.
+
+    Args:
+      key_dtype: the type of the key tensors.
+      value_dtype: the type of the value tensors.
+      default_value: The value to use if a key is missing in the table.
+      shared_name: If non-empty, this table will be shared under
+        the given name across multiple sessions.
+      name: A name for the operation (optional).
+      checkpoint: if True, the contents of the table are saved to and restored
+        from checkpoints. If `shared_name` is empty for a checkpointed table, it
+        is shared using the table node name.
+
+    Returns:
+      A `MutableHashTable` object.
+
+    Raises:
+      ValueError: If checkpoint is True and no name was specified.
+    """
+    self._default_value = ops.convert_to_tensor(default_value,
+                                                dtype=value_dtype)
+    self._value_shape = self._default_value.get_shape()
+
+    # The table must be shared if checkpointing is requested for multi-worker
+    # training to work correctly. Use the node name if no shared_name has been
+    # explicitly specified.
+    use_node_name_sharing = checkpoint and shared_name is None
+    if self._default_value.get_shape().ndims == 0:
+      self._table_ref = gen_lookup_ops.mutable_hash_table_v2(
+          shared_name=shared_name,
+          use_node_name_sharing=use_node_name_sharing,
+          key_dtype=key_dtype,
+          value_dtype=value_dtype,
+          name=name)
+    else:
+      self._table_ref = gen_lookup_ops.mutable_hash_table_of_tensors_v2(
+          shared_name=shared_name,
+          use_node_name_sharing=use_node_name_sharing,
+          key_dtype=key_dtype,
+          value_dtype=value_dtype,
+          value_shape=self._default_value.get_shape(),
+          name=name)
+    super(MutableHashTable, self).__init__(key_dtype, value_dtype,
+                                           self._table_ref.op.name.split(
+                                               "/")[-1])
+
+    if checkpoint:
+      saveable = MutableHashTable._Saveable(self, name)
+      ops.add_to_collection(ops.GraphKeys.SAVEABLE_OBJECTS, saveable)
+
+  def size(self, name=None):
+    """Compute the number of elements in this table.
+
+    Args:
+      name: A name for the operation (optional).
+
+    Returns:
+      A scalar tensor containing the number of elements in this table.
+    """
+    with ops.name_scope(name, "%s_Size" % self._name,
+                        [self._table_ref]) as name:
+      with ops.colocate_with(self._table_ref):
+        return gen_lookup_ops.lookup_table_size_v2(self._table_ref, name=name)
+
+  def lookup(self, keys, name=None):
+    """Looks up `keys` in a table, outputs the corresponding values.
+
+    The `default_value` is used for keys not present in the table.
+
+    Args:
+      keys: Keys to look up. Can be a tensor of any shape. Must match the
+        table's key_dtype.
+      name: A name for the operation (optional).
+
+    Returns:
+      A tensor containing the values in the same shape as `keys` using the
+        table's value type.
+
+    Raises:
+      TypeError: when `keys` do not match the table data types.
+    """
+    if keys.dtype.base_dtype != self._key_dtype:
+      raise TypeError("Signature mismatch. Keys must be dtype %s, got %s." %
+                      (self._key_dtype, keys.dtype))
+
+    with ops.name_scope(name, "%s_lookup_table_find" % self._name,
+                        (self._table_ref, keys, self._default_value)) as name:
+      with ops.colocate_with(self._table_ref):
+        values = gen_lookup_ops.lookup_table_find_v2(
+            self._table_ref, keys, self._default_value, name=name)
+
+        values.set_shape(keys.get_shape().concatenate(self._value_shape))
+    return values
+
+  def insert(self, keys, values, name=None):
+    """Associates `keys` with `values`.
+
+    Args:
+      keys: Keys to insert. Can be a tensor of any shape. Must match the
+        table's key type.
+      values: Values to be associated with keys. Must be a tensor of the same
+        shape as `keys` and match the table's value type.
+      name: A name for the operation (optional).
+
+    Returns:
+      The created Operation.
+
+    Raises:
+      TypeError: when `keys` or `values` doesn't match the table data
+        types.
+    """
+    # pylint: disable=protected-access
+    lookup_ops._check_table_dtypes(self, keys.dtype, values.dtype)
+    # pylint: enable=protected-access
+    with ops.name_scope(name, "%s_lookup_table_insert" % self._name,
+                        [self._table_ref, keys, values]) as name:
+      with ops.colocate_with(self._table_ref):
+        # pylint: disable=protected-access
+        op = gen_lookup_ops.lookup_table_insert_v2(
+            self._table_ref, keys, values, name=name)
+    return op
+
+  def export(self, name=None):
+    """Returns tensors of all keys and values in the table.
+
+    Args:
+      name: A name for the operation (optional).
+
+    Returns:
+      A pair of tensors with the first tensor containing all keys and the
+        second tensors containing all values in the table.
+    """
+    with ops.name_scope(name, "%s_lookup_table_export_values" % self._name,
+                        [self._table_ref]) as name:
+      with ops.colocate_with(self._table_ref):
+        exported_keys, exported_values = gen_lookup_ops.lookup_table_export_v2(
+            self._table_ref, self._key_dtype, self._value_dtype, name=name)
+
+    exported_values.set_shape(exported_keys.get_shape().concatenate(
+        self._value_shape))
+    return exported_keys, exported_values
+
+  class _Saveable(BaseSaverBuilder.SaveableObject):
+    """SaveableObject implementation for MutableHashTable."""
+
+    def __init__(self, table, name):
+      tensors = table.export()
+      specs = [
+          BaseSaverBuilder.SaveSpec(tensors[0], "", name + "-keys"),
+          BaseSaverBuilder.SaveSpec(tensors[1], "", name + "-values")
+      ]
+      # pylint: disable=protected-access
+      super(MutableHashTable._Saveable, self).__init__(table, specs, name)
+
+    def restore(self, restored_tensors, unused_restored_shapes):
+      # pylint: disable=protected-access
+      with ops.colocate_with(self.op._table_ref):
+        return gen_lookup_ops.lookup_table_import_v2(
+            self.op._table_ref, restored_tensors[0], restored_tensors[1])
+
+
+class MutableDenseHashTable(LookupInterface):
+  """A generic mutable hash table implementation using tensors as backing store.
+
+  Data can be inserted by calling the insert method. It does not support
+  initialization via the init method.
+
+  It uses "open addressing" with quadratic reprobing to resolve collisions.
+  Compared to `MutableHashTable` the insert and lookup operations in a
+  `MutableDenseHashTable` are typically faster, but memory usage can be higher.
+  However, `MutableDenseHashTable` does not require additional memory for
+  temporary tensors created during checkpointing and restore operations.
+
+  Example usage:
+
+  ```python
+  table = tf.contrib.lookup.MutableDenseHashTable(key_dtype=tf.int64,
+                                                  value_dtype=tf.int64,
+                                                  default_value=-1,
+                                                  empty_key=0)
+  sess.run(table.insert(keys, values))
+  out = table.lookup(query_keys)
+  print(out.eval())
+  ```
+  """
+
+  # TODO(andreasst): consider extracting common code with MutableHashTable into
+  # a common superclass.
+  def __init__(self,
+               key_dtype,
+               value_dtype,
+               default_value,
+               empty_key,
+               initial_num_buckets=None,
+               shared_name=None,
+               name="MutableDenseHashTable",
+               checkpoint=True):
+    """Creates an empty `MutableDenseHashTable` object.
+
+    Creates a table, the type of its keys and values are specified by key_dtype
+    and value_dtype, respectively.
+
+    Args:
+      key_dtype: the type of the key tensors.
+      value_dtype: the type of the value tensors.
+      default_value: The value to use if a key is missing in the table.
+      empty_key: the key to use to represent empty buckets internally. Must not
+        be used in insert or lookup operations.
+      initial_num_buckets: the initial number of buckets.
+      shared_name: If non-empty, this table will be shared under
+        the given name across multiple sessions.
+      name: A name for the operation (optional).
+      checkpoint: if True, the contents of the table are saved to and restored
+        from checkpoints. If `shared_name` is empty for a checkpointed table, it
+        is shared using the table node name.
+
+    Returns:
+      A `MutableHashTable` object.
+
+    Raises:
+      ValueError: If checkpoint is True and no name was specified.
+    """
+    self._default_value = ops.convert_to_tensor(
+        default_value, dtype=value_dtype)
+    self._value_shape = self._default_value.get_shape()
+
+    # The table must be shared if checkpointing is requested for multi-worker
+    # training to work correctly. Use the node name if no shared_name has been
+    # explicitly specified.
+    use_node_name_sharing = checkpoint and shared_name is None
+    empty_key = ops.convert_to_tensor(empty_key, dtype=key_dtype)
+    self._table_ref = gen_lookup_ops.mutable_dense_hash_table_v2(
+        empty_key=empty_key,
+        shared_name=shared_name,
+        use_node_name_sharing=use_node_name_sharing,
+        value_dtype=value_dtype,
+        value_shape=self._value_shape,
+        initial_num_buckets=initial_num_buckets,
+        name=name)
+    super(MutableDenseHashTable, self).__init__(
+        key_dtype, value_dtype, self._table_ref.op.name.split("/")[-1])
+
+    if checkpoint:
+      saveable = MutableDenseHashTable._Saveable(self, name)
+      ops.add_to_collection(ops.GraphKeys.SAVEABLE_OBJECTS, saveable)
+
+  def size(self, name=None):
+    """Compute the number of elements in this table.
+
+    Args:
+      name: A name for the operation (optional).
+
+    Returns:
+      A scalar tensor containing the number of elements in this table.
+    """
+    with ops.name_scope(name, "%s_Size" % self._name,
+                        [self._table_ref]) as name:
+      with ops.colocate_with(self._table_ref):
+        return gen_lookup_ops.lookup_table_size_v2(self._table_ref, name=name)
+
+  def lookup(self, keys, name=None):
+    """Looks up `keys` in a table, outputs the corresponding values.
+
+    The `default_value` is used for keys not present in the table.
+
+    Args:
+      keys: Keys to look up. Can be a tensor of any shape. Must match the
+        table's key_dtype.
+      name: A name for the operation (optional).
+
+    Returns:
+      A tensor containing the values in the same shape as `keys` using the
+        table's value type.
+
+    Raises:
+      TypeError: when `keys` do not match the table data types.
+    """
+    if keys.dtype.base_dtype != self._key_dtype:
+      raise TypeError("Signature mismatch. Keys must be dtype %s, got %s." %
+                      (self._key_dtype, keys.dtype))
+
+    with ops.name_scope(name, "%s_lookup_table_find" % self._name,
+                        [self._table_ref, keys]) as name:
+      with ops.colocate_with(self._table_ref):
+        values = gen_lookup_ops.lookup_table_find_v2(
+            self._table_ref, keys, self._default_value, name=name)
+
+    if keys.get_shape().ndims is not None and keys.get_shape().ndims > 0:
+      values.set_shape(
+          tensor_shape.TensorShape([keys.get_shape().dims[0]]).concatenate(
+              self._value_shape))
+    return values
+
+  def insert(self, keys, values, name=None):
+    """Associates `keys` with `values`.
+
+    Args:
+      keys: Keys to insert. Can be a tensor of any shape. Must match the
+        table's key type.
+      values: Values to be associated with keys. Must be a tensor of the same
+        shape as `keys` and match the table's value type.
+      name: A name for the operation (optional).
+
+    Returns:
+      The created Operation.
+
+    Raises:
+      TypeError: when `keys` or `values` doesn't match the table data
+        types.
+    """
+    # pylint: disable=protected-access
+    lookup_ops._check_table_dtypes(self, keys.dtype, values.dtype)
+    # pylint: enable=protected-access
+    with ops.name_scope(name, "%s_lookup_table_insert" % self._name,
+                        [self._table_ref, keys, values]) as name:
+      with ops.colocate_with(self._table_ref):
+        op = gen_lookup_ops.lookup_table_insert_v2(
+            self._table_ref, keys, values, name=name)
+      return op
+
+  def export(self, name=None):
+    """Returns tensors of all keys and values in the table.
+
+    Args:
+      name: A name for the operation (optional).
+
+    Returns:
+      A pair of tensors with the first tensor containing all keys and the
+        second tensors containing all values in the table.
+    """
+    with ops.name_scope(name, "%s_lookup_table_export_values" % self._name,
+                        [self._table_ref]) as name:
+      with ops.colocate_with(self._table_ref):
+        exported_keys, exported_values = gen_lookup_ops.lookup_table_export_v2(
+            self._table_ref, self._key_dtype, self._value_dtype, name=name)
+
+    exported_values.set_shape(exported_keys.get_shape().concatenate(
+        self._value_shape))
+    return exported_keys, exported_values
+
+  class _Saveable(BaseSaverBuilder.SaveableObject):
+    """SaveableObject implementation for MutableDenseHashTable."""
+
+    def __init__(self, table, name):
+      tensors = table.export()
+      specs = [
+          BaseSaverBuilder.SaveSpec(tensors[0], "", name + "-keys"),
+          BaseSaverBuilder.SaveSpec(tensors[1], "", name + "-values")
+      ]
+      # pylint: disable=protected-access
+      super(MutableDenseHashTable._Saveable, self).__init__(table, specs, name)
+
+    def restore(self, restored_tensors, unused_restored_shapes):
+      # pylint: disable=protected-access
+      with ops.colocate_with(self.op._table_ref):
+        return gen_lookup_ops.lookup_table_import_v2(
+            self.op._table_ref, restored_tensors[0], restored_tensors[1])

--- a/astronet/ops/slim_training.py
+++ b/astronet/ops/slim_training.py
@@ -1,0 +1,552 @@
+# coding=utf-8
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains various routines and helper functions for training models.
+
+This script contains various functions for training models. These include
+manipulating gradients, creating a `train_op` (an operation that computes the
+loss and applies the gradients) and a training loop function. The training loop
+allows the user to pass in the `train_op` and runs the optimization according
+to user-specified arguments.
+
+************************************
+* A simple working training script *
+************************************
+
+  # Load data and create the model:
+  images, labels = LoadData(...)
+  predictions = MyModel(images)
+
+  # Define the loss:
+  tf_slim.losses.log_loss(predictions, labels)
+  total_loss = tf_slim.losses.losses.get_total_loss()
+
+  # Define the optimizer:
+  optimizer = tf.compat.v1.train.MomentumOptimizer(FLAGS.learning_rate,
+  FLAGS.momentum)
+
+  # Create the train_op
+  train_op = tf_slim.training.create_train_op(total_loss, optimizer)
+
+  # Run training.
+  tf_slim.training.train(train_op, my_log_dir)
+
+*************************
+* Creating the train_op *
+*************************
+
+In order to use the `train` function, one needs a train_op: an `Operation` that
+(a) computes the loss, (b) applies the gradients to update the weights and
+(c) returns the value of the loss. tf_slim.training.create_train_op creates
+such an `Operation`. This function also provides the ability to manipulate
+the gradients using a few arguments:
+
+  # Create the train_op and clip the gradient norms:
+  train_op = tf_slim.training.create_train_op(
+      total_loss,
+      optimizer,
+      transform_grads_fn=clip_gradient_norms_fn(3))
+
+  # Create the train_op and scale the gradients by providing a map from variable
+  # name (or variable) to a scaling coefficient:
+  def transform_grads_fn(grads):
+    gradient_multipliers = {
+      'conv0/weights': 1.2,
+      'fc8/weights': 3.4,
+    }
+    return tf_slim.training.multiply_gradients(
+            grads, gradient_multipliers)
+
+  train_op = tf_slim.training.create_train_op(
+      total_loss,
+      optimizer,
+      transform_grads_fn=transform_grads_fn)
+
+****************************************************************
+* Performing additional (non-gradient) updates during training *
+****************************************************************
+
+Many networks utilize modules, like BatchNorm, that require performing a series
+of non-gradient updates during training  tf_slim.training.create_train_op
+allows a user to pass in a list of update_ops to call along with the gradient
+updates.
+
+  train_op = tf_slim.training.create_train_op(
+      total_loss, optimizer, update_ops)
+
+By default, tf_slim.training.create_train_op includes all update ops that are
+part of the `tf.GraphKeys.UPDATE_OPS` collection. Additionally, the
+tf_slim.batch_norm function adds the moving mean and moving variance
+updates to this collection. Consequently, users who want to use
+tf_slim.batch_norm will not need to take any additional steps in order
+to have the moving mean and moving variance updates be computed.
+
+However, users with additional, specialized updates can either override the
+default update ops or simply add additional update ops to the
+`tf.GraphKeys.UPDATE_OPS` collection:
+
+  # Force `create_train_op` to NOT use ANY update_ops:
+  train_op = tf_slim.training.create_train_op(
+     total_loss,
+     optimizer,
+     update_ops=[])
+
+  # Use an alternative set of update ops:
+  train_op = tf_slim.training.create_train_op(
+     total_loss,
+     optimizer,
+     update_ops=my_other_update_ops)
+
+  # Use a set of update ops in addition to the default updates:
+  tf.compat.v1.add_to_collection(tf.GraphKeys.UPDATE_OPS, my_update0)
+  tf.compat.v1.add_to_collection(tf.GraphKeys.UPDATE_OPS, my_update1)
+
+  train_op = tf_slim.training.create_train_op(
+     total_loss,
+     optimizer)
+
+  # Which is the same as:
+  train_op = tf_slim.training.create_train_op(
+     total_loss,
+     optimizer,
+     update_ops=tf.compat.v1.get_collection(tf.GraphKeys.UPDATE_OPS))
+
+******************************************
+* Initializing a model from a checkpoint *
+******************************************
+
+It is common to want to 'warm-start' a model from a pre-trained checkpoint.
+One can use a tf.Scaffold and an initializing function to do so.
+
+  ...
+
+  # Create the train_op
+  train_op = tf_slim.training.create_train_op(total_loss, optimizer)
+
+  # Create the initial assignment op
+  checkpoint_path = '/path/to/old_model_checkpoint'
+  variables_to_restore = tf_slim.get_model_variables()
+  init_fn = tf.assign_from_checkpoint_fn(
+      checkpoint_path, variables_to_restore)
+
+  # Run training.
+  scaffold = tf.Scaffold(init_fn=init_fn)
+  tf_slim.training.train(train_op, my_log_dir, scaffold=scaffold)
+
+***************************************************************************
+* Initializing a model from a checkpoint whose variable names don't match *
+***************************************************************************
+
+At times, a user may want to initialize a new model with values from a
+checkpoint whose variable names do not match those of the current model. In this
+case, one needs to create a mapping from the checkpoint variable names to the
+current model variables. This requires only a small modification of the code
+above:
+  ...
+  # Creates a model with two variables, var0 and var1
+  predictions = MyModel(images)
+  ...
+
+  # Create the train_op
+  train_op = tf_slim.training.create_train_op(total_loss, optimizer)
+
+  checkpoint_path = '/path/to/old_model_checkpoint'
+
+  # Create the mapping:
+  variables_to_restore = {
+      'name_var_0_in_checkpoint':
+          tf_slim.get_unique_variable('var0'),
+      'name_var_1_in_checkpoint':
+          tf_slim.get_unique_variable('var1')
+  }
+  init_fn = tf_slim.framework.assign_from_checkpoint_fn(
+        checkpoint_path, variables_to_restore)
+  scaffold = tf.Scaffold(init_fn=init_fn)
+
+  # Run training.
+  tf_slim.training.train(train_op, my_log_dir, scaffold=scaffold)
+
+
+*************************************************
+* Fine-Tuning Part of a model from a checkpoint *
+*************************************************
+
+Rather than initializing all of the weights of a given model, we sometimes
+only want to restore some of the weights from a checkpoint. To do this, one
+need only filter those variables to initialize as follows:
+
+  ...
+
+  # Create the train_op
+  train_op = tf_slim.training.create_train_op(total_loss, optimizer)
+
+  checkpoint_path = '/path/to/old_model_checkpoint'
+
+  # Specify the variables to restore via a list of inclusion or exclusion
+  # patterns:
+  variables_to_restore = tf_slim.get_variables_to_restore(
+      include=["conv"], exclude=["fc8", "fc9])
+  # or
+  variables_to_restore = tf_slim.get_variables_to_restore(
+      exclude=["conv"])
+
+  init_fn = tf_slim.assign_from_checkpoint_fn(
+      checkpoint_path, variables_to_restore)
+  scaffold = tf.Scaffold(init_fn=init_fn)
+
+  # Run training.
+  tf_slim.training.train(train_op, my_log_dir, scaffold=scaffold)
+
+******************************************************
+* Initializing model variables from values in memory *
+******************************************************
+
+One may want to initialize the weights of a model from values coming from an
+arbitrary source (a text document, matlab file, etc). While this is technically
+feasible using assign operations, this strategy results in the values of your
+weights being stored in the graph. For large models, this becomes prohibitively
+large. However, it's possible to perform this initial assignment without having
+to store the values of the initial model in the graph itself by using
+placeholders and a feed dictionary:
+
+  ...
+
+  # Create the train_op
+  train_op = tf_slim.training.create_train_op(total_loss, optimizer)
+
+  # Create the mapping from variable names to values:
+  var0_initial_value = ReadFromDisk(...)
+  var1_initial_value = ReadFromDisk(...)
+
+  var_names_to_values = {
+    'var0': var0_initial_value,
+    'var1': var1_initial_value,
+  }
+
+  init_fn = tf_slim.assign_from_values_fn(var_names_to_values)
+  scaffold = tf.Scaffold(init_fn=init_fn)
+
+  # Run training.
+  tf_slim.training.train(train_op, my_log_dir, scaffold=scaffold)
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# pylint: disable=g-direct-tensorflow-import
+
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import clip_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import variables as tf_variables
+from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.summary import summary
+from tensorflow.python.training import monitored_session
+from tensorflow.python.training import optimizer as tf_optimizer
+from tensorflow.python.training import training_util
+
+
+__all__ = [
+    'add_gradients_summaries',
+    'clip_gradient_norms',
+    'clip_gradient_norms_fn',
+    'create_train_op',
+    'multiply_gradients',
+    'train',
+]
+
+
+def add_gradients_summaries(grads_and_vars):
+  """Add summaries to gradients.
+
+  Args:
+    grads_and_vars: A list of gradient to variable pairs (tuples).
+
+  Returns:
+    The list of created summaries.
+  """
+  summaries = []
+  for grad, var in grads_and_vars:
+    if grad is not None:
+      if isinstance(grad, ops.IndexedSlices):
+        grad_values = grad.values
+      else:
+        grad_values = grad
+      summaries.append(
+          summary.histogram(var.op.name + '_gradient', grad_values))
+      summaries.append(
+          summary.scalar(var.op.name + '_gradient_norm',
+                         clip_ops.global_norm([grad_values])))
+    else:
+      logging.info('Var %s has no gradient', var.op.name)
+
+  return summaries
+
+
+def clip_gradient_norms(gradients_to_variables, max_norm):
+  """Clips the gradients by the given value.
+
+  Args:
+    gradients_to_variables: A list of gradient to variable pairs (tuples).
+    max_norm: the maximum norm value.
+
+  Returns:
+    A list of clipped gradient to variable pairs.
+  """
+  clipped_grads_and_vars = []
+  for grad, var in gradients_to_variables:
+    if grad is not None:
+      if isinstance(grad, ops.IndexedSlices):
+        tmp = clip_ops.clip_by_norm(grad.values, max_norm)
+        grad = ops.IndexedSlices(tmp, grad.indices, grad.dense_shape)
+      else:
+        grad = clip_ops.clip_by_norm(grad, max_norm)
+    clipped_grads_and_vars.append((grad, var))
+  return clipped_grads_and_vars
+
+
+def clip_gradient_norms_fn(max_norm):
+  """Returns a `transform_grads_fn` function for gradient clipping."""
+
+  def clip_norms(gradients_to_variables):
+    return clip_gradient_norms(gradients_to_variables, max_norm)
+
+  return clip_norms
+
+
+def multiply_gradients(grads_and_vars, gradient_multipliers):
+  """Multiply specified gradients.
+
+  Args:
+    grads_and_vars: A list of gradient to variable pairs (tuples).
+    gradient_multipliers: A map from either `Variables` or `Variable` op names
+      to the coefficient by which the associated gradient should be scaled.
+
+  Returns:
+    The updated list of gradient to variable pairs.
+
+  Raises:
+    ValueError: If `grads_and_vars` is not a list or if `gradient_multipliers`
+    is empty or None or if `gradient_multipliers` is not a dictionary.
+  """
+  if not isinstance(grads_and_vars, list):
+    raise ValueError('`grads_and_vars` must be a list.')
+  if not gradient_multipliers:
+    raise ValueError('`gradient_multipliers` is empty.')
+  if not isinstance(gradient_multipliers, dict):
+    raise ValueError('`gradient_multipliers` must be a dict.')
+
+  multiplied_grads_and_vars = []
+  for grad, var in grads_and_vars:
+    if var in gradient_multipliers or var.op.name in gradient_multipliers:
+      key = var if var in gradient_multipliers else var.op.name
+      if grad is None:
+        raise ValueError('Requested multiple of `None` gradient.')
+
+      if isinstance(grad, ops.IndexedSlices):
+        tmp = grad.values * ops.convert_to_tensor(
+            gradient_multipliers[key], dtype=grad.dtype)
+        grad = ops.IndexedSlices(tmp, grad.indices, grad.dense_shape)
+      else:
+        grad *= ops.convert_to_tensor(
+            gradient_multipliers[key], dtype=grad.dtype)
+    multiplied_grads_and_vars.append((grad, var))
+  return multiplied_grads_and_vars
+
+
+_USE_GLOBAL_STEP = 0
+
+
+def create_train_op(total_loss,
+                    optimizer,
+                    global_step=_USE_GLOBAL_STEP,
+                    update_ops=None,
+                    variables_to_train=None,
+                    transform_grads_fn=None,
+                    summarize_gradients=False,
+                    gate_gradients=tf_optimizer.Optimizer.GATE_OP,
+                    aggregation_method=None,
+                    colocate_gradients_with_ops=False,
+                    check_numerics=True):
+  """Creates an `Operation` that evaluates the gradients and returns the loss.
+
+  Args:
+    total_loss: A `Tensor` representing the total loss.
+    optimizer: A tf.Optimizer to use for computing the gradients.
+    global_step: A `Tensor` representing the global step variable. If left as
+      `_USE_GLOBAL_STEP`, then tf.train.global_step() is used.
+    update_ops: An optional list of updates to execute. If `update_ops` is
+      `None`, then the update ops are set to the contents of the
+      `tf.GraphKeys.UPDATE_OPS` collection. If `update_ops` is not `None`, but
+      it doesn't contain all of the update ops in `tf.GraphKeys.UPDATE_OPS`, a
+      warning will be displayed.
+    variables_to_train: an optional list of variables to train. If None, it will
+      default to all tf.compat.v1.trainable_variables().
+    transform_grads_fn: A function which takes a single argument, a list of
+      gradient to variable pairs (tuples), performs any requested gradient
+      updates, such as gradient clipping or multipliers, and returns the updated
+      list.
+    summarize_gradients: Whether or not add summaries for each gradient.
+    gate_gradients: How to gate the computation of gradients. See tf.Optimizer.
+    aggregation_method: Specifies the method used to combine gradient terms.
+      Valid values are defined in the class `AggregationMethod`.
+    colocate_gradients_with_ops: Whether or not to try colocating the gradients
+      with the ops that generated them.
+    check_numerics: Whether or not we apply check_numerics.
+
+  Returns:
+    A `Tensor` that when evaluated, computes the gradients and returns the total
+      loss value.
+  """
+  if global_step is _USE_GLOBAL_STEP:  # pylint: disable=g-int-id-comparison
+    global_step = training_util.get_or_create_global_step()
+
+  # Update ops use GraphKeys.UPDATE_OPS collection if update_ops is None.
+  global_update_ops = set(ops.get_collection(ops.GraphKeys.UPDATE_OPS))
+  if update_ops is None:
+    update_ops = global_update_ops
+  else:
+    update_ops = set(update_ops)
+  if not global_update_ops.issubset(update_ops):
+    logging.warning('update_ops in create_train_op does not contain all the '
+                    'update_ops in GraphKeys.UPDATE_OPS')
+
+  # Make sure update_ops are computed before total_loss.
+  if update_ops:
+    with ops.control_dependencies(update_ops):
+      barrier = control_flow_ops.no_op(name='update_barrier')
+    total_loss = control_flow_ops.with_dependencies([barrier], total_loss)
+
+  if variables_to_train is None:
+    # Default to tf.compat.v1.trainable_variables()
+    variables_to_train = tf_variables.trainable_variables()
+  else:
+    # Make sure that variables_to_train are in
+    # tf.compat.v1.trainable_variables()
+    for v in variables_to_train:
+      assert v.trainable or v in tf_variables.trainable_variables()
+
+  assert variables_to_train
+
+  # Create the gradients. Note that apply_gradients adds the gradient
+  # computation to the current graph.
+  grads = optimizer.compute_gradients(
+      total_loss,
+      variables_to_train,
+      gate_gradients=gate_gradients,
+      aggregation_method=aggregation_method,
+      colocate_gradients_with_ops=colocate_gradients_with_ops)
+
+  if transform_grads_fn:
+    grads = transform_grads_fn(grads)
+
+  # Summarize gradients.
+  if summarize_gradients:
+    with ops.name_scope('summarize_grads'):
+      add_gradients_summaries(grads)
+
+  # Create gradient updates.
+  grad_updates = optimizer.apply_gradients(grads, global_step=global_step)
+
+  with ops.name_scope('train_op'):
+    # Make sure total_loss is valid.
+    if check_numerics:
+      total_loss = array_ops.check_numerics(total_loss,
+                                            'LossTensor is inf or nan')
+
+    # Ensure the train_tensor computes grad_updates.
+    train_op = control_flow_ops.with_dependencies([grad_updates], total_loss)
+
+  # Add the operation used for training to the 'train_op' collection
+  train_ops = ops.get_collection_ref(ops.GraphKeys.TRAIN_OP)
+  if train_op not in train_ops:
+    train_ops.append(train_op)
+
+  return train_op
+
+
+def train(train_op,
+          logdir,
+          master='',
+          is_chief=True,
+          scaffold=None,
+          hooks=None,
+          chief_only_hooks=None,
+          save_checkpoint_secs=600,
+          save_summaries_steps=100,
+          config=None,
+          max_wait_secs=7200,
+          run_metadata=None):
+  """Runs the training loop.
+
+  Args:
+    train_op: A `Tensor` that, when executed, will apply the gradients and
+      return the loss value.
+    logdir: The directory where the graph and checkpoints are saved.
+    master: The URL of the master.
+    is_chief: Specifies whether or not the training is being run by the primary
+      replica during replica training.
+    scaffold: An tf.compat.v1.train.Scaffold instance.
+    hooks: List of `tf.estimator.SessionRunHook` callbacks which are run inside
+      the training loop.
+    chief_only_hooks: List of `tf.estimator.SessionRunHook` instances which are
+      run inside the training loop for the chief trainer only.
+    save_checkpoint_secs: The frequency, in seconds, that a checkpoint is saved
+      using a default checkpoint saver. If `save_checkpoint_secs` is set to
+      `None`, then the default checkpoint saver isn't used.
+    save_summaries_steps: The frequency, in number of global steps, that the
+      summaries are written to disk using a default summary saver. If
+      `save_summaries_steps` is set to `None`, then the default summary saver
+      isn't used.
+    config: An instance of `tf.compat.v1.ConfigProto`.
+    max_wait_secs: Maximum time workers should wait for the session to become
+      available. This should be kept relatively short to help detect incorrect
+      code, but sometimes may need to be increased if the chief takes a while to
+      start up.
+    run_metadata: A [`RunMetadata`] protocol buffer.
+
+  Returns:
+    the value of the loss function after training.
+
+  Raises:
+    ValueError: if `logdir` is `None` and either `save_checkpoint_secs` or
+    `save_summaries_steps` are `None.
+  """
+  if logdir is None and is_chief:
+    if save_summaries_steps:
+      raise ValueError(
+          'logdir cannot be None when save_summaries_steps is not None')
+
+    if save_checkpoint_secs:
+      raise ValueError(
+          'logdir cannot be None when save_checkpoint_secs is not None')
+
+  with monitored_session.MonitoredTrainingSession(
+      master=master,
+      is_chief=is_chief,
+      checkpoint_dir=logdir,
+      scaffold=scaffold,
+      hooks=hooks,
+      chief_only_hooks=chief_only_hooks,
+      save_checkpoint_secs=save_checkpoint_secs,
+      save_summaries_steps=save_summaries_steps,
+      config=config,
+      max_wait_secs=max_wait_secs) as session:
+    loss = None
+    while not session.should_stop():
+      loss = session.run(train_op, run_metadata=run_metadata)
+  return loss

--- a/astronet/ops/training.py
+++ b/astronet/ops/training.py
@@ -19,88 +19,89 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
+import astronet.ops.slim_training as slim_training
 
 
 def create_learning_rate(hparams, global_step):
-  """Creates a learning rate Tensor.
+    """Creates a learning rate Tensor.
 
-  Args:
-    hparams: ConfigDict containing the learning rate configuration.
-    global_step: The global step Tensor.
+    Args:
+      hparams: ConfigDict containing the learning rate configuration.
+      global_step: The global step Tensor.
 
-  Returns:
-    A learning rate Tensor.
-  """
-  if hparams.get("learning_rate_decay_factor"):
-    learning_rate = tf.compat.v1.train.exponential_decay(
-        learning_rate=float(hparams.learning_rate),
-        global_step=global_step,
-        decay_steps=hparams.learning_rate_decay_steps,
-        decay_rate=hparams.learning_rate_decay_factor,
-        staircase=hparams.learning_rate_decay_staircase)
-  else:
-    learning_rate = tf.constant(hparams.learning_rate)
+    Returns:
+      A learning rate Tensor.
+    """
+    if hparams.get("learning_rate_decay_factor"):
+        learning_rate = tf.compat.v1.train.exponential_decay(
+            learning_rate=float(hparams.learning_rate),
+            global_step=global_step,
+            decay_steps=hparams.learning_rate_decay_steps,
+            decay_rate=hparams.learning_rate_decay_factor,
+            staircase=hparams.learning_rate_decay_staircase)
+    else:
+        learning_rate = tf.constant(hparams.learning_rate)
 
-  return learning_rate
+    return learning_rate
 
 
 def create_optimizer(hparams, learning_rate, use_tpu=False):
-  """Creates a TensorFlow Optimizer.
+    """Creates a TensorFlow Optimizer.
 
-  Args:
-    hparams: ConfigDict containing the optimizer configuration.
-    learning_rate: A Python float or a scalar Tensor.
-    use_tpu: If True, the returned optimizer is wrapped in a
-        CrossShardOptimizer.
+    Args:
+      hparams: ConfigDict containing the optimizer configuration.
+      learning_rate: A Python float or a scalar Tensor.
+      use_tpu: If True, the returned optimizer is wrapped in a
+          CrossShardOptimizer.
 
-  Returns:
-    A TensorFlow optimizer.
+    Returns:
+      A TensorFlow optimizer.
 
-  Raises:
-    ValueError: If hparams.optimizer is unrecognized.
-  """
-  optimizer_name = hparams.optimizer.lower()
-  if optimizer_name == "momentum":
-    optimizer = tf.compat.v1.train.MomentumOptimizer(
-        learning_rate,
-        momentum=hparams.get("momentum", 0.9),
-        use_nesterov=hparams.get("use_nesterov", False))
-  elif optimizer_name == "sgd":
-    optimizer = tf.compat.v1.train.GradientDescentOptimizer(learning_rate)
-  elif optimizer_name == "adagrad":
-    optimizer = tf.compat.v1.train.AdagradOptimizer(learning_rate)
-  elif optimizer_name == "adam":
-    optimizer = tf.compat.v1.train.AdamOptimizer(learning_rate)
-  elif optimizer_name == "rmsprop":
-    optimizer = tf.RMSPropOptimizer(learning_rate)
-  else:
-    raise ValueError("Unknown optimizer: %s" % hparams.optimizer)
+    Raises:
+      ValueError: If hparams.optimizer is unrecognized.
+    """
+    optimizer_name = hparams.optimizer.lower()
+    if optimizer_name == "momentum":
+        optimizer = tf.compat.v1.train.MomentumOptimizer(
+            learning_rate,
+            momentum=hparams.get("momentum", 0.9),
+            use_nesterov=hparams.get("use_nesterov", False))
+    elif optimizer_name == "sgd":
+        optimizer = tf.compat.v1.train.GradientDescentOptimizer(learning_rate)
+    elif optimizer_name == "adagrad":
+        optimizer = tf.compat.v1.train.AdagradOptimizer(learning_rate)
+    elif optimizer_name == "adam":
+        optimizer = tf.compat.v1.train.AdamOptimizer(learning_rate)
+    elif optimizer_name == "rmsprop":
+        optimizer = tf.RMSPropOptimizer(learning_rate)
+    else:
+        raise ValueError("Unknown optimizer: %s" % hparams.optimizer)
 
-  if use_tpu:
-    optimizer = tf.compat.v1.tpu.CrossShardOptimizer(optimizer)
+    if use_tpu:
+        optimizer = tf.compat.v1.tpu.CrossShardOptimizer(optimizer)
 
-  return optimizer
+    return optimizer
 
 
 def create_train_op(model, optimizer):
-  """Creates a Tensor to train the model.
+    """Creates a Tensor to train the model.
 
-  Args:
-    model: Instance of AstroModel.
-    optimizer: Instance of tf.train.Optimizer.
+    Args:
+      model: Instance of AstroModel.
+      optimizer: Instance of tf.train.Optimizer.
 
-  Returns:
-    A Tensor that runs a single training step and returns model.total_loss.
-  """
-  # Maybe clip gradient norms.
-  transform_grads_fn = None
-  if model.hparams.get("clip_grad_norm"):
-    transform_grads_fn = tf.contrib.training.clip_gradient_norms_fn(
-        model.hparams.clip_gradient_norm)
+    Returns:
+      A Tensor that runs a single training step and returns model.total_loss.
+    """
+    # Maybe clip gradient norms.
+    transform_grads_fn = None
+    if model.hparams.get("clip_grad_norm"):
+        transform_grads_fn = slim_training.clip_gradient_norms_fn(
+            model.hparams.clip_gradient_norm)
 
-  # Create train op.
-  return tf.contrib.training.create_train_op(
-      total_loss=model.total_loss,
-      optimizer=optimizer,
-      global_step=model.global_step,
-      transform_grads_fn=transform_grads_fn)
+    # Create train op.
+    return slim_training.create_train_op(
+        total_loss=model.total_loss,
+        optimizer=optimizer,
+        global_step=model.global_step,
+        transform_grads_fn=transform_grads_fn)

--- a/astronet/ops/variables.py
+++ b/astronet/ops/variables.py
@@ -1,0 +1,857 @@
+# coding=utf-8
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Variable functions."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+import re
+import tensorflow.compat.v1 as tf
+import astronet.ops.arg_scope as arg_scope
+# pylint: disable=g-direct-tensorflow-import
+from tensorflow.core.protobuf import saver_pb2
+from tensorflow.python.framework import device as tf_device
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import variable_scope
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.training import saver as tf_saver
+from tensorflow.python.training import training_util
+from tensorflow.python.util.deprecation import deprecated
+
+
+__all__ = ['add_model_variable',
+           'assert_global_step',
+           'assert_or_get_global_step',
+           'assign_from_checkpoint',
+           'assign_from_checkpoint_fn',
+           'assign_from_values',
+           'assign_from_values_fn',
+           'create_global_step',
+           'filter_variables',
+           'get_global_step',
+           'get_or_create_global_step',
+           'get_local_variables',
+           'get_model_variables',
+           'get_trainable_variables',
+           'get_unique_variable',
+           'get_variables_by_name',
+           'get_variables_by_suffix',
+           'get_variable_full_name',
+           'get_variables_to_restore',
+           'get_variables',
+           'global_variable',
+           'local_variable',
+           'model_variable',
+           'variable',
+           'VariableDeviceChooser']
+
+
+@deprecated(None, 'Please switch to tf.train.assert_global_step')
+def assert_global_step(global_step_tensor):
+    training_util.assert_global_step(global_step_tensor)
+
+
+def assert_or_get_global_step(graph=None, global_step_tensor=None):
+    """Verifies that a global step tensor is valid or gets one if None is given.
+
+    If `global_step_tensor` is not None, check that it is a valid global step
+    tensor (using `assert_global_step`). Otherwise find a global step tensor using
+    `get_global_step` and return it.
+
+    Args:
+      graph: The graph to find the global step tensor for.
+      global_step_tensor: The tensor to check for suitability as a global step. If
+        None is given (the default), find a global step tensor.
+
+    Returns:
+      A tensor suitable as a global step, or `None` if none was provided and none
+      was found.
+    """
+    if global_step_tensor is None:
+        # Get the global step tensor the same way the supervisor would.
+        global_step_tensor = get_global_step(graph)
+    else:
+        assert_global_step(global_step_tensor)
+    return global_step_tensor
+
+
+@deprecated(None, 'Please switch to tf.train.get_global_step')
+def get_global_step(graph=None):
+    return training_util.get_global_step(graph)
+
+
+@deprecated(None, 'Please switch to tf.train.create_global_step')
+def create_global_step(graph=None):
+    """Create global step tensor in graph.
+
+    This API is deprecated. Use core framework training version instead.
+
+    Args:
+      graph: The graph in which to create the global step tensor. If missing, use
+        default graph.
+
+    Returns:
+      Global step tensor.
+
+    Raises:
+      ValueError: if global step tensor is already defined.
+    """
+    return training_util.create_global_step(graph)
+
+
+@deprecated(None, 'Please switch to tf.train.get_or_create_global_step')
+def get_or_create_global_step(graph=None):
+    """Returns and create (if necessary) the global step tensor.
+
+    Args:
+      graph: The graph in which to create the global step tensor. If missing, use
+        default graph.
+
+    Returns:
+      The global step tensor.
+    """
+    return training_util.get_or_create_global_step(graph)
+
+
+def local_variable(initial_value,
+                   validate_shape=True,
+                   name=None,
+                   use_resource=None):
+    """Create a variable with a value and add it to `GraphKeys.LOCAL_VARIABLES`.
+
+    Args:
+      initial_value: See variables.Variable.__init__.
+      validate_shape: See variables.Variable.__init__.
+      name: See variables.Variable.__init__.
+      use_resource: If `True` use a ResourceVariable instead of a Variable.
+
+    Returns:
+      New variable.
+    """
+    return variable_scope.variable(
+        initial_value,
+        trainable=False,
+        collections=[ops.GraphKeys.LOCAL_VARIABLES],
+        validate_shape=validate_shape,
+        use_resource=use_resource,
+        name=name)
+
+
+def global_variable(initial_value,
+                    validate_shape=True,
+                    name=None,
+                    use_resource=None):
+    """Create a variable with a value and add it to `GraphKeys.GLOBAL_VARIABLES`.
+
+    Args:
+      initial_value: See variables.Variable.__init__.
+      validate_shape: See variables.Variable.__init__.
+      name: See variables.Variable.__init__.
+      use_resource: If `True` use a ResourceVariable instead of a Variable.
+
+    Returns:
+      New variable.
+    """
+    return variable_scope.variable(
+        initial_value,
+        trainable=False,
+        collections=[ops.GraphKeys.GLOBAL_VARIABLES],
+        validate_shape=validate_shape,
+        use_resource=use_resource,
+        name=name)
+
+
+@arg_scope.add_arg_scope
+def variable(name,
+             shape=None,
+             dtype=None,
+             initializer=None,
+             regularizer=None,
+             trainable=True,
+             collections=None,
+             caching_device=None,
+             device=None,
+             partitioner=None,
+             custom_getter=None,
+             use_resource=None,
+             synchronization=variables.VariableSynchronization.AUTO,
+             aggregation=variables.VariableAggregation.NONE):
+    """Gets an existing variable with these parameters or creates a new one.
+
+    Args:
+      name: the name of the new or existing variable.
+      shape: shape of the new or existing variable.
+      dtype: type of the new or existing variable (defaults to `DT_FLOAT`).
+      initializer: initializer for the variable if one is created.
+      regularizer: a (Tensor -> Tensor or None) function; the result of applying
+        it on a newly created variable will be added to the collection
+        GraphKeys.REGULARIZATION_LOSSES and can be used for regularization.
+      trainable: If `True` also add the variable to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+      collections: A list of collection names to which the Variable will be added.
+        If None it would default to `tf.GraphKeys.GLOBAL_VARIABLES`.
+      caching_device: Optional device string or function describing where the
+        Variable should be cached for reading.  Defaults to the Variable's device.
+      device: Optional device to place the variable. It can be an string or a
+        function that is called to get the device for the variable.
+      partitioner: Optional callable that accepts a fully defined `TensorShape`
+        and dtype of the `Variable` to be created, and returns a list of
+        partitions for each axis (currently only one axis can be partitioned).
+      custom_getter: Callable that allows overwriting the internal get_variable
+        method and has to have the same signature.
+      use_resource: If `True` use a ResourceVariable instead of a Variable.
+      synchronization: Indicates when a distributed a variable will be aggregated.
+        Accepted values are constants defined in the class
+        `tf.VariableSynchronization`. By default the synchronization is set to
+        `AUTO` and the current `DistributionStrategy` chooses when to synchronize.
+        If `synchronization` is set to `ON_READ`, `trainable` must not be set to
+        `True`.
+      aggregation: Indicates how a distributed variable will be aggregated.
+        Accepted values are constants defined in the class
+        `tf.VariableAggregation`.
+
+    Returns:
+      The created or existing variable.
+    """
+    collections = list(collections if collections is not None else
+                       [ops.GraphKeys.GLOBAL_VARIABLES])
+
+    # Remove duplicates
+    collections = list(set(collections))
+    getter = variable_scope.get_variable
+    if custom_getter is not None:
+        getter = functools.partial(
+            custom_getter, reuse=variable_scope.get_variable_scope().reuse)
+    with ops.device(device or ''):
+        return getter(
+            name,
+            shape=shape,
+            dtype=dtype,
+            initializer=initializer,
+            regularizer=regularizer,
+            trainable=trainable,
+            collections=collections,
+            caching_device=caching_device,
+            partitioner=partitioner,
+            use_resource=use_resource,
+            synchronization=synchronization,
+            aggregation=aggregation)
+
+
+@arg_scope.add_arg_scope
+def model_variable(name,
+                   shape=None,
+                   dtype=dtypes.float32,
+                   initializer=None,
+                   regularizer=None,
+                   trainable=True,
+                   collections=None,
+                   caching_device=None,
+                   device=None,
+                   partitioner=None,
+                   custom_getter=None,
+                   use_resource=None,
+                   synchronization=variables.VariableSynchronization.AUTO,
+                   aggregation=variables.VariableAggregation.NONE):
+    """Gets an existing model variable with these parameters or creates a new one.
+
+    Args:
+      name: the name of the new or existing variable.
+      shape: shape of the new or existing variable.
+      dtype: type of the new or existing variable (defaults to `DT_FLOAT`).
+      initializer: initializer for the variable if one is created.
+      regularizer: a (Tensor -> Tensor or None) function; the result of applying
+        it on a newly created variable will be added to the collection
+        GraphKeys.REGULARIZATION_LOSSES and can be used for regularization.
+      trainable: If `True` also add the variable to the graph collection
+        `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+      collections: A list of collection names to which the Variable will be added.
+        Note that the variable is always also added to the
+        `GraphKeys.GLOBAL_VARIABLES` and `GraphKeys.MODEL_VARIABLES` collections.
+      caching_device: Optional device string or function describing where the
+        Variable should be cached for reading.  Defaults to the Variable's device.
+      device: Optional device to place the variable. It can be an string or a
+        function that is called to get the device for the variable.
+      partitioner: Optional callable that accepts a fully defined `TensorShape`
+        and dtype of the `Variable` to be created, and returns a list of
+        partitions for each axis (currently only one axis can be partitioned).
+      custom_getter: Callable that allows overwriting the internal get_variable
+        method and has to have the same signature.
+      use_resource: If `True` use a ResourceVariable instead of a Variable.
+      synchronization: Indicates when a distributed a variable will be aggregated.
+        Accepted values are constants defined in the class
+        `tf.VariableSynchronization`. By default the synchronization is set to
+        `AUTO` and the current `DistributionStrategy` chooses when to synchronize.
+        If `synchronization` is set to `ON_READ`, `trainable` must not be set to
+        `True`.
+      aggregation: Indicates how a distributed variable will be aggregated.
+        Accepted values are constants defined in the class
+        `tf.VariableAggregation`.
+
+    Returns:
+      The created or existing variable.
+    """
+    collections = list(collections or [])
+    collections += [ops.GraphKeys.GLOBAL_VARIABLES,
+                    ops.GraphKeys.MODEL_VARIABLES]
+    var = variable(
+        name,
+        shape=shape,
+        dtype=dtype,
+        initializer=initializer,
+        regularizer=regularizer,
+        trainable=trainable,
+        collections=collections,
+        caching_device=caching_device,
+        device=device,
+        partitioner=partitioner,
+        custom_getter=custom_getter,
+        use_resource=use_resource,
+        synchronization=synchronization,
+        aggregation=aggregation)
+    return var
+
+
+def add_model_variable(var):
+    """Adds a variable to the `GraphKeys.MODEL_VARIABLES` collection.
+
+    Args:
+      var: a variable.
+    """
+    if var not in ops.get_collection(ops.GraphKeys.MODEL_VARIABLES):
+        ops.add_to_collection(ops.GraphKeys.MODEL_VARIABLES, var)
+
+
+def get_variables(scope=None,
+                  suffix=None,
+                  collection=ops.GraphKeys.GLOBAL_VARIABLES):
+    """Gets the list of variables, filtered by scope and/or suffix.
+
+    Args:
+      scope: an optional scope for filtering the variables to return. Can be a
+        variable scope or a string.
+      suffix: an optional suffix for filtering the variables to return.
+      collection: in which collection search for. Defaults to
+        `GraphKeys.GLOBAL_VARIABLES`.
+
+    Returns:
+      a list of variables in collection with scope and suffix.
+    """
+    if scope and isinstance(scope, variable_scope.VariableScope):
+        scope = scope.name
+    if suffix is not None:
+        if ':' not in suffix:
+            suffix += ':'
+        scope = (scope or '') + '.*' + suffix
+    return ops.get_collection(collection, scope)
+
+
+def get_model_variables(scope=None, suffix=None):
+    """Gets the list of model variables, filtered by scope and/or suffix.
+
+    Args:
+      scope: an optional scope for filtering the variables to return.
+      suffix: an optional suffix for filtering the variables to return.
+
+    Returns:
+      a list of variables in collection with scope and suffix.
+    """
+    return get_variables(scope, suffix, ops.GraphKeys.MODEL_VARIABLES)
+
+
+def get_local_variables(scope=None, suffix=None):
+    """Gets the list of local variables, filtered by scope and/or suffix.
+
+    Args:
+      scope: an optional scope for filtering the variables to return.
+      suffix: an optional suffix for filtering the variables to return.
+
+    Returns:
+      a list of variables in collection with scope and suffix.
+    """
+    return get_variables(scope, suffix, ops.GraphKeys.LOCAL_VARIABLES)
+
+
+def get_trainable_variables(scope=None, suffix=None):
+    """Gets the list of trainable variables, filtered by scope and/or suffix.
+
+    Args:
+      scope: an optional scope for filtering the variables to return.
+      suffix: an optional suffix for filtering the variables to return.
+
+    Returns:
+      a list of variables in the trainable collection with scope and suffix.
+    """
+    return get_variables(scope, suffix, ops.GraphKeys.TRAINABLE_VARIABLES)
+
+
+def get_variables_to_restore(include=None, exclude=None):
+    """Gets the list of the variables to restore.
+
+    Args:
+      include: an optional list/tuple of scope strings for filtering which
+        variables from the VARIABLES collection to include. None would include all
+        the variables.
+      exclude: an optional list/tuple of scope strings for filtering which
+        variables from the VARIABLES collection to exclude. None it would not
+        exclude any.
+
+    Returns:
+      a list of variables to restore.
+
+    Raises:
+      TypeError: include or exclude is provided but is not a list or a tuple.
+    """
+    if include is None:
+        # Include all variables.
+        vars_to_include = get_variables()
+    else:
+        if not isinstance(include, (list, tuple)):
+            raise TypeError(
+                'include is provided but is not a list or a tuple.')
+        vars_to_include = []
+        for scope in include:
+            vars_to_include += get_variables(scope)
+    vars_to_exclude = set()
+    if exclude is not None:
+        if not isinstance(exclude, (list, tuple)):
+            raise TypeError(
+                'exclude is provided but is not a list or a tuple.')
+        for scope in exclude:
+            vars_to_exclude |= set(get_variables(scope))
+    # Exclude the variables in vars_to_exclude
+    return [v for v in vars_to_include if v not in vars_to_exclude]
+
+
+def get_variables_by_suffix(suffix, scope=None):
+    """Gets the list of variables that end with the given suffix.
+
+    Args:
+      suffix: suffix for filtering the variables to return.
+      scope: an optional scope for filtering the variables to return.
+
+    Returns:
+      a copied list of variables with the given name and prefix.
+    """
+    return get_variables(scope=scope, suffix=suffix)
+
+
+def get_variables_by_name(given_name, scope=None):
+    """Gets the list of variables that were given that name.
+
+    Args:
+      given_name: name given to the variable without any scope.
+      scope: an optional scope for filtering the variables to return.
+
+    Returns:
+      a copied list of variables with the given name and scope.
+    """
+    suffix = '/' + given_name + ':|^' + given_name + ':'
+    return get_variables(scope=scope, suffix=suffix)
+
+
+def get_unique_variable(var_op_name):
+    """Gets the variable uniquely identified by that var_op_name.
+
+    Args:
+      var_op_name: the full name of the variable op, including the scope.
+
+    Returns:
+      a tensorflow variable.
+
+    Raises:
+      ValueError: if no variable uniquely identified by the name exists.
+    """
+    candidates = get_variables(scope=var_op_name)
+    if not candidates:
+        raise ValueError('Couldn\'t find variable %s' % var_op_name)
+
+    for candidate in candidates:
+        if candidate.op.name == var_op_name:
+            return candidate
+    raise ValueError('Variable %s does not uniquely identify a variable' %
+                     var_op_name)
+
+
+def assign_from_values(var_names_to_values):
+    """Creates an assignment operation from a given mapping.
+
+    This function provides a mechanism for performing assignment of variables
+    to values in a way that does not fill the graph with large assignment values.
+
+    Args:
+      var_names_to_values: A map from variable names to values.
+
+    Returns:
+      assign_op: An `Operation` that assigns each of the given variables to the
+        requested values.
+      feed_dict: The feed dictionary to use when evaluating `assign_op`.
+
+    Raises:
+      ValueError: if any of the given variable names were not found.
+    """
+    feed_dict = {}
+    assign_ops = []
+
+    for var_name in var_names_to_values:
+        var_value = var_names_to_values[var_name]
+        var = ops.get_collection(ops.GraphKeys.GLOBAL_VARIABLES, var_name)
+        if not var:
+            raise ValueError('Variable %s wasn\'t found' % var_name)
+        elif len(var) > 1:
+            # tf.compat.v1.get_collection is just a filter on the prefix:
+            # find the exact match:
+            found = False
+            for v in var:
+                if v.op.name == var_name:
+                    var = v
+                    found = True
+                    break
+
+            if not found:
+                raise ValueError('Variable %s doesn\'t uniquely identify a variable' %
+                                 var_name)
+        else:
+            var = var[0]
+
+        placeholder_name = 'placeholder/' + var.op.name
+        placeholder_value = array_ops.placeholder(
+            dtype=var.dtype.base_dtype,
+            shape=var.get_shape(),
+            name=placeholder_name)
+        assign_ops.append(var.assign(placeholder_value))
+
+        feed_dict[placeholder_value] = var_value.reshape(var.get_shape())
+
+    assign_op = control_flow_ops.group(*assign_ops)
+    return assign_op, feed_dict
+
+
+def assign_from_values_fn(var_names_to_values):
+    """Returns a function that assigns specific variables from the given values.
+
+    This function provides a mechanism for performing assignment of variables
+    to values in a way that does not fill the graph with large assignment values.
+
+    Args:
+      var_names_to_values: A map from variable names to values.
+
+    Returns:
+      A function that takes a single argument, a `tf.compat.v1.Session`, that
+      applies the
+      assignment operation.
+
+    Raises:
+      ValueError: if any of the given variable names were not found.
+    """
+    assign_op, feed_dict = assign_from_values(var_names_to_values)
+
+    def callback(session):
+        return session.run(assign_op, feed_dict)
+
+    return callback
+
+
+# pylint: disable=protected-access
+# Currently variable_scope doesn't provide very good APIs to access
+# all variables under scope and retrieve and check existing scopes.
+def get_variable_full_name(var):
+    """Returns the full name of a variable.
+
+    For normal Variables, this is the same as the var.op.name.  For
+    sliced or PartitionedVariables, this name is the same for all the
+    slices/partitions. In both cases, this is normally the name used in
+    a checkpoint file.
+
+    Args:
+      var: A `Variable` object.
+
+    Returns:
+      A string that is the full name.
+    """
+    if var._save_slice_info:
+        return var._save_slice_info.full_name
+    else:
+        return var.op.name
+
+
+def assign_from_checkpoint(model_path, var_list, ignore_missing_vars=False):
+    """Creates an operation to assign specific variables from a checkpoint.
+
+    Args:
+      model_path: The full path to the model checkpoint. To get latest checkpoint
+        use `model_path = tf.train.latest_checkpoint(checkpoint_dir)`
+      var_list: A list of (possibly partitioned) `Variable` objects or a
+        dictionary mapping names in the checkpoint to the corresponding variables
+        or list of variables to initialize from that checkpoint value. For
+        partitioned Variables, the name in the checkpoint must be the full
+        variable, not the name of the partitioned variable, eg. "my_var" rather
+        than "my_var/part_4". If empty, returns no_op(), {}.
+      ignore_missing_vars: Boolean, if True ignore variables missing in the
+        checkpoint with a warning instead of failing.
+
+    Returns:
+      the restore_op and the feed_dict that need to be run to restore var_list.
+
+    Raises:
+      ValueError: If `ignore_missing_vars` is False and the checkpoint specified
+          at `model_path` is missing one of the variables in `var_list`.
+    """
+    # Normalize var_list into a dictionary mapping names in the
+    # checkpoint to the list of variables to initialize from that
+    # checkpoint variable. Sliced (including partitioned) variables will
+    # end up under the same key.
+    grouped_vars = {}
+    if isinstance(var_list, (tuple, list)):
+        for var in var_list:
+            ckpt_name = get_variable_full_name(var)
+            if ckpt_name not in grouped_vars:
+                grouped_vars[ckpt_name] = []
+            grouped_vars[ckpt_name].append(var)
+
+    else:
+        for ckpt_name, value in var_list.items():
+            if isinstance(value, (tuple, list)):
+                grouped_vars[ckpt_name] = value
+            else:
+                grouped_vars[ckpt_name] = [value]
+
+    # Read each checkpoint entry. Create a placeholder variable and
+    # add the (possibly sliced) data from the checkpoint to the feed_dict.
+    reader = tf.train.NewCheckpointReader(model_path)
+    feed_dict = {}
+    assign_ops = []
+    for ckpt_name in grouped_vars:
+        if not reader.has_tensor(ckpt_name):
+            log_str = 'Checkpoint is missing variable [%s]' % ckpt_name
+            if ignore_missing_vars:
+                logging.warning(log_str)
+                continue
+            else:
+                raise ValueError(log_str)
+        ckpt_value = reader.get_tensor(ckpt_name)
+
+        for var in grouped_vars[ckpt_name]:
+            placeholder_tensor = array_ops.placeholder(
+                dtype=var.dtype.base_dtype,
+                shape=var.get_shape(),
+                name='placeholder/' + var.op.name)
+            assign_ops.append(var.assign(placeholder_tensor))
+
+            if not var._save_slice_info:
+                if var.get_shape() != ckpt_value.shape:
+                    raise ValueError(
+                        'Total size of new array must be unchanged for %s '
+                        'lh_shape: [%s], rh_shape: [%s]' %
+                        (ckpt_name, str(ckpt_value.shape), str(var.get_shape())))
+
+                feed_dict[placeholder_tensor] = ckpt_value.reshape(
+                    ckpt_value.shape)
+            else:
+                slice_dims = zip(var._save_slice_info.var_offset,
+                                 var._save_slice_info.var_shape)
+                slice_dims = [(start, start + size)
+                              for (start, size) in slice_dims]
+                slice_dims = [slice(*x) for x in slice_dims]
+                slice_value = ckpt_value[slice_dims]
+                slice_value = slice_value.reshape(
+                    var._save_slice_info.var_shape)
+                feed_dict[placeholder_tensor] = slice_value
+
+    assign_op = control_flow_ops.group(*assign_ops)
+    return assign_op, feed_dict
+
+
+# pylint: enable=protected-access
+
+
+def assign_from_checkpoint_fn(model_path,
+                              var_list,
+                              ignore_missing_vars=False,
+                              reshape_variables=False):
+    """Returns a function that assigns specific variables from a checkpoint.
+
+    If ignore_missing_vars is True and no variables are found in the checkpoint
+    it returns None.
+
+    Args:
+      model_path: The full path to the model checkpoint. To get latest checkpoint
+        use `model_path = tf.train.latest_checkpoint(checkpoint_dir)`
+      var_list: A list of `Variable` objects or a dictionary mapping names in the
+        checkpoint to the corresponding variables to initialize. If empty or
+        `None`, it would return `no_op(), None`.
+      ignore_missing_vars: Boolean, if True it would ignore variables missing in
+        the checkpoint with a warning instead of failing.
+      reshape_variables: Boolean, if True it would automatically reshape variables
+        which are of different shape then the ones stored in the checkpoint but
+        which have the same number of elements.
+
+    Returns:
+      A function that takes a single argument, a `tf.compat.v1.Session`, that
+      applies the
+      assignment operation. If no matching variables were found in the checkpoint
+      then `None` is returned.
+
+    Raises:
+      ValueError: If var_list is empty.
+    """
+    if not var_list:
+        raise ValueError('var_list cannot be empty')
+    if ignore_missing_vars:
+        reader = tf.train.NewCheckpointReader(model_path)
+        if isinstance(var_list, dict):
+            var_dict = var_list
+        else:
+            var_dict = {var.op.name: var for var in var_list}
+        available_vars = {}
+        for var in var_dict:
+            if reader.has_tensor(var):
+                available_vars[var] = var_dict[var]
+            else:
+                logging.warning(
+                    'Variable %s missing in checkpoint %s', var, model_path)
+        var_list = available_vars
+    if var_list:
+        saver = tf_saver.Saver(
+            var_list,
+            reshape=reshape_variables,
+            write_version=saver_pb2.SaverDef.V1)
+
+        def callback(session):
+            saver.restore(session, model_path)
+
+        return callback
+    else:
+        logging.warning('No Variables to restore')
+        return None
+
+
+class VariableDeviceChooser(object):
+    """Device chooser for variables.
+
+    When using a parameter server it will assign them in a round-robin fashion.
+    When not using a parameter server it allows GPU or CPU placement.
+    """
+
+    def __init__(self,
+                 num_tasks=0,
+                 job_name='ps',
+                 device_type='CPU',
+                 device_index=0,
+                 replica=None):
+        """Initialize VariableDeviceChooser.
+
+        Usage:
+          To use with 2 parameter servers:
+            VariableDeviceChooser(2)
+
+          To use without parameter servers:
+            VariableDeviceChooser()
+            VariableDeviceChooser(device_type='GPU') # For GPU placement
+
+        Args:
+          num_tasks: number of tasks.
+          job_name: String, a name for the parameter server job.
+          device_type: Optional device type string (e.g. "CPU" or "GPU")
+          device_index: int.  Optional device index.  If left unspecified, device
+            represents 'any' device_index.
+          replica: replica index.
+        """
+        self._job_name = job_name
+        self._device_type = device_type
+        self._device_index = device_index
+        self._replica = replica
+        self._num_tasks = num_tasks
+        self._next_task_id = 0
+
+    def __call__(self, op):
+        device_spec = tf_device.DeviceSpec(
+            replica=self._replica,
+            device_type=self._device_type,
+            device_index=self._device_index)
+        if self._num_tasks > 0:
+            task_id = self._next_task_id
+            self._next_task_id = (self._next_task_id + 1) % self._num_tasks
+            device_spec.job = self._job_name
+            device_spec.task = task_id
+        return device_spec.to_string()
+
+
+def filter_variables(var_list,
+                     include_patterns=None,
+                     exclude_patterns=None,
+                     reg_search=True):
+    """Filter a list of variables using regular expressions.
+
+    First includes variables according to the list of include_patterns.
+    Afterwards, eliminates variables according to the list of exclude_patterns.
+
+    For example, one can obtain a list of variables with the weights of all
+    convolutional layers (depending on the network definition) by:
+
+    ```python
+    variables = tf_slim.get_model_variables()
+    conv_weight_variables = tf_slim.filter_variables(
+        variables,
+        include_patterns=['Conv'],
+        exclude_patterns=['biases', 'Logits'])
+    ```
+
+    Args:
+      var_list: list of variables.
+      include_patterns: list of regular expressions to include. Defaults to None,
+        which means all variables are selected according to the include rules. A
+        variable is included if it matches any of the include_patterns.
+      exclude_patterns: list of regular expressions to exclude. Defaults to None,
+        which means all variables are selected according to the exclude rules. A
+        variable is excluded if it matches any of the exclude_patterns.
+      reg_search: boolean. If True (default), performs re.search to find matches
+        (i.e. pattern can match any substring of the variable name). If False,
+        performs re.match (i.e. regexp should match from the beginning of the
+        variable name).
+
+    Returns:
+      filtered list of variables.
+    """
+    if reg_search:
+        reg_exp_func = re.search
+    else:
+        reg_exp_func = re.match
+
+    # First include variables.
+    if include_patterns is None:
+        included_variables = list(var_list)
+    else:
+        included_variables = []
+        for var in var_list:
+            if any(reg_exp_func(ptrn, var.name) for ptrn in include_patterns):
+                included_variables.append(var)
+
+    # Afterwards, exclude variables.
+    if exclude_patterns is None:
+        filtered_variables = included_variables
+    else:
+        filtered_variables = []
+        for var in included_variables:
+            if not any(reg_exp_func(ptrn, var.name) for ptrn in exclude_patterns):
+                filtered_variables.append(var)
+
+    return filtered_variables


### PR DESCRIPTION
TLDR: Google sucks, this was harder than it needed to be, but the TF2
issues should be solved now.

The issue here was that usage of tf.contrib cannot be replaced
automatically by the upgrade script. It seems that several libraries in
tf.contrib have not been automatically ported. Google really bungled the
upgrade process from TF1 to TF2. They have not managed backwards
compatability well with little to no thought to existing users. This
was not an easy task to solve, and the only entity to blame here is
Google. You can track the upgrade process of TF1 contrib functionality
here:
https://docs.google.com/spreadsheets/d/1FLFJLzg7WNP6JHODX5q8BDgptKafq_slHpnHVbJIteQ/edit#gid=0
(Notice how empty the sheet is)

Fortunately, the functionality required by astronet was ported to a
separate library Google created called tf-slim. There is no
documentation that they did that, and it is instead left to the user to
discover that. Why not include that information in the TF2 upgrade page?
Who knows why Google seems to hate their users?

However, it's not just as easy pip installing tf-slim, because while
the GitHub repository has updated code, the actual pip package is not
updated and still contains references to tf.contrib. Why not update the
pip package if its such a major release? No good reason other than pure
mismanagement of this upgrade process. I don't know if anyone at Google
really even thought through this well.

Anyways, I managed to cherry pick the exact functionality astronet
needed from tf-slim and put it into astronet itself and modified the
imports. Everything should work correctly now.